### PR TITLE
feat: add confirmed variant IDs with retailer evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Status Icon Legend:
 | --------------------- | ------------- | ---------- | ------ |
 | Cobalt Blue Metallic  | 13600         | A02-B2     | ✅     |
 | Oxide Green Metallic  | 13500         | ?          | ❌     |
-| Iridium Gold Metallic | 13400         | ?          | ❌     |
+| Iridium Gold Metallic | 13400         | A02-Y1     | ❌     |
 | Copper Brown Metallic | 13800         | ?          | ❌     |
-| Iron Gray Metallic    | 13100         | ?          | ❌     |
+| Iron Gray Metallic    | 13100         | A02-D2     | ❌     |
 
 #### PLA Silk+
 
@@ -219,10 +219,10 @@ Status Icon Legend:
 | ------------ | ------------- | ---------- | ------ |
 | Burgundy Red | 14200         | ?          | ❌     |
 | Matcha Green | 14500         | ?          | ❌     |
-| Lava Gray    | 14101         | ?          | ❌     |
+| Lava Gray    | 14101         | A50-D6     | ❌     |
 | Jeans Blue   | 14600         | ?          | ❌     |
 | Black        | 14100         | A50-K0     | ✅     |
-| Royal Blue   | 14601         | ?          | ❌     |
+| Royal Blue   | 14601         | A50-B6     | ❌     |
 | Iris Purple  | 14700         | ?          | ❌     |
 
 #### PLA Tough+
@@ -306,13 +306,13 @@ Status Icon Legend:
 | Color  | Filament Code | Variant ID | Status |
 | ------ | ------------- | ---------- | ------ |
 | Orange | 41300         | B50-A0     | ✅     |
-| Green  | 41500         | ?          | ❌     |
-| Red    | 41200         | ?          | ❌     |
+| Green  | 41500         | B50-G0     | ❌     |
+| Red    | 41200         | B50-R0     | ❌     |
 | Yellow | 41400         | ?          | ❌     |
 | Blue   | 41600         | ?          | ❌     |
-| White  | 41100         | ?          | ❌     |
+| White  | 41100         | B50-W0     | ❌     |
 | Gray   | 41102         | ?          | ❌     |
-| Black  | 41101         | ?          | ❌     |
+| Black  | 41101         | B50-K0     | ❌     |
 
 ### ASA
 


### PR DESCRIPTION
## Summary

This PR adds variant IDs that have been **confirmed through direct evidence** from specific retail product pages. This represents only entries with verifiable, linkable sources.

## Confirmed Variant IDs Added

### PLA-CF Series
- **A50-D6** (Lava Gray) - [Confirmed via PBTech product page](https://www.pbtech.co.nz/product/MPRPLA0031)
- **A50-B6** (Royal Blue) - [Confirmed via Futurology Tech listings](https://www.futurology.tech/collections/pla-filament)

### PLA Metal Series  
- **A02-Y1** (Iridium Gold Metallic) - [Confirmed via Futurology Tech listings](https://www.futurology.tech/collections/pla-filament)
- **A02-D2** (Iron Gray Metallic) - [Confirmed via Futurology Tech and PBTech](https://www.pbtech.co.nz/product/MPRPLA0032)

### ABS-GF Series
- **B50-G0** (Green) - [Confirmed via Futurology Tech](https://futurology.tech/products/bambu-lab-000400) - SKU: B50-G0-1.75-1000-SPL
- **B50-R0** (Red) - [Confirmed via Futurology Tech](https://futurology.tech/products/bambu-lab-000399) - SKU: B50-R0-1.75-1000-SPL
- **B50-W0** (White) - [Confirmed via Futurology Tech](https://futurology.tech/products/bambu-lab-000396) - SKU: B50-W0-1.75-1000-SPL
- **B50-K0** (Black) - [Confirmed via Futurology Tech](https://futurology.tech/products/bambu-lab-000395) - SKU: B50-K0-1.75-1000-SPL

## Evidence Standards

**Strict Requirements Met:**
- ✅ Direct confirmation from retail product pages
- ✅ Specific product codes matching filament database  
- ✅ Cross-referenced across multiple retailers where possible
- ✅ Clickable links to source evidence
- ✅ Product SKU codes that exactly match variant ID format

**What This PR Does NOT Include:**
- ❌ Pattern-based inferences (handled separately in PR #27)
- ❌ Vague "confirmed via retailers" without specific links
- ❌ Assumptions based on series patterns

## Total Added
**8 variant IDs** with direct retail source evidence

## Next Steps

A follow-up PR (#27) will add additional variant IDs based on pattern inference from this confirmed data set.

## Related

- **Part 1** of split from original PR #25
- **Follow-up PR**: #27 (pattern-based inferences)
- **Standards**: Only entries with specific, linkable retail evidence