### PR TITLE
Add foundation scripts: categories, key derivation, utilities, checker, repair

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Shared category / material lookup tables used by multiple scripts.
+# Import from here instead of duplicating these definitions.
+
+# Maps filament_type values to top-level library category folder names
+CATEGORY_MAP = {
+    'PA-S':     'Support Material',
+    'PLA-S':    'Support Material',
+    'Support':  'Support Material',
+    'PVA':      'Support Material',
+    'ABS-S':    'Support Material',
+    'PETG-CF':  'PETG',
+    'TPU-AMS':  'TPU',
+    'ABS-GF':   'ABS',
+    'PLA-CF':   'PLA',
+    'PA-CF':    'PA',
+    'PA-GF':    'PA',
+    'ASA-CF':   'ASA',
+    'ASA Aero': 'ASA',
+}
+
+# Maps tag detailed_filament_type values for materials shared across multiple library folders.
+# Value is (single_colour_folder, multi_colour_folder).
+# Note: 'PLA Silk+' stores 'PLA Silk+' in the tag and needs no entry here.
+#       'PLA Silk' covers two distinct products:
+#         - PLA Silk (discontinued single-colour) -> PLA Silk/
+#         - PLA Silk Multi-Color                  -> PLA Silk Multi-Color/
+MULTI_COLOR_MATERIAL_MAP = {
+    'PLA Silk': ('PLA Silk', 'PLA Silk Multi-Color'),
+}
+
+# Maps tag detailed_filament_type values to additional acceptable library subfolder names.
+# Entries here are alternatives — the primary expected folder comes from resolve_material().
+MATERIAL_MAP = {
+    'Support for PA':  ['Support for PA-PET'],
+    'Support For PA':  ['Support for PA-PET'],
+    'Support G':       ['Support for PA-PET'],
+    'Support W':       ['Support for PLA-PETG'],
+    'Support for PLA': ['Support for PLA (New Version)', 'Support for PLA-PETG'],
+    'PETG-CF':         ['PETG CF'],
+    'PLA Basic':       ['PLA Basic Gradient'],
+    'PLA':             ['PLA Silk Multi-Color'],
+}
+
+
+def resolve_material(tag_data):
+    """
+    Return the canonical library folder name for a tag's material.
+    For materials in MULTI_COLOR_MATERIAL_MAP, multi-colour tags map to the
+    multi folder; single-colour tags map to the single folder.
+    """
+    base = tag_data['detailed_filament_type']
+    if base in MULTI_COLOR_MATERIAL_MAP:
+        single_folder, multi_folder = MULTI_COLOR_MATERIAL_MAP[base]
+        return multi_folder if tag_data.get('filament_color_count', 1) > 1 else single_folder
+    return base
+
+
+def allowed_material_folders(tag_data):
+    """
+    Return a list of acceptable library subfolder names for a tag's material.
+    For MULTI_COLOR_MATERIAL_MAP entries only the resolved folder name is valid
+    (the raw tag value is not a real library folder name).
+    For other materials the expected folder, the raw tag value, and any MATERIAL_MAP
+    aliases are all acceptable.
+    """
+    raw_mat = tag_data['detailed_filament_type']
+    expected_mat = resolve_material(tag_data)
+
+    if raw_mat in MULTI_COLOR_MATERIAL_MAP:
+        single_folder, multi_folder = MULTI_COLOR_MATERIAL_MAP[raw_mat]
+        if tag_data.get('filament_color_count', 1) > 1:
+            return [multi_folder]
+        else:
+            return [single_folder]
+    else:
+        extra = MATERIAL_MAP.get(raw_mat, [])
+        if not isinstance(extra, list):
+            extra = [extra]
+        return list(dict.fromkeys([expected_mat, raw_mat] + extra))

--- a/deriveKeys.py
+++ b/deriveKeys.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Python script to generate keys for Bambu Lab RFID tags
+# Created for https://github.com/Bambu-Research-Group/RFID-Tag-Guide
+# Written by thekakester (https://github.com/thekakester) and Vinyl Da.i'gyu-Kazotetsu (www.queengoob.org), 2024
+# Requires: pycryptodome
+
+import sys
+from Crypto.Protocol.KDF import HKDF
+from Crypto.Hash import SHA256
+
+if not sys.version_info >= (3, 6):
+   print("Python 3.6 or higher is required!")
+   exit(-1)
+
+def kdf(uid):
+    salt = bytes([0x9a,0x75,0x9c,0xf2,0xc4,0xf7,0xca,0xff,0x22,0x2c,0xb9,0x76,0x9b,0x41,0xbc,0x96])
+    return [HKDF(uid, 6, salt, SHA256, 16, context=b"RFID-A\0"), HKDF(uid, 6, salt, SHA256, 16, context=b"RFID-B\0")]
+
+if __name__ == '__main__':
+    uid = bytes.fromhex(sys.argv[1])
+    keys = kdf(uid)
+
+    output = [k.hex().upper() for k in [*keys[0], *keys[1]]]
+    print("\n".join(output))

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+# Common functions used throughout the project
+# Created for https://github.com/Bambu-Research-Group/RFID-Tag-Guide
+
+import re
+import subprocess
+import os
+import sys
+import struct
+from pathlib import Path
+from datetime import datetime
+
+if not sys.version_info >= (3, 6):
+  raise Exception("Python 3.6 or higher is required!")
+  
+#Some keys come surrounded in terminal color codes such as "[32m63654db94d97[0m"
+#We need to remove these
+def strip_color_codes(input_string):
+    # Define the regular expression pattern to match ANSI escape sequences
+    ansi_escape = re.compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]')
+    # Use the sub method to replace the escape sequences with an empty string
+    return ansi_escape.sub('', input_string)
+
+def run_command(command, pipe=True):
+    print(' '.join([str(c) for c in command]))
+    try:
+        result = subprocess.run(command, shell=os.name == 'nt', capture_output=pipe)
+        if result.returncode not in (0, 1):
+            print(f"Warning: command exited with code {result.returncode}")
+            return None
+        return result.stdout.decode("utf-8").strip().replace('\r\n', '\n') if pipe else ""
+    except Exception as e:
+        print(f"Error running command: {e}")
+        return None
+
+def get_proxmark3_location():
+    # Find a "pm3" command that works from a list of OS-specific possibilities
+    print("Checking program: pm3")
+
+    # Check PROXMARK3_DIR environment variable
+    if os.environ.get('PROXMARK3_DIR'):
+        pm3_dir = Path(os.environ['PROXMARK3_DIR'])
+        pm3_bin = pm3_dir / "bin" / "pm3"
+        # On Windows the wrapper is pm3.bat; on Unix it is pm3 (no extension)
+        pm3_exists = pm3_bin.exists() or (os.name == 'nt' and (pm3_dir / "bin" / "pm3.bat").exists())
+        if pm3_exists:
+            print(f"Found installation via PROXMARK3_DIR ({pm3_dir})!")
+            return pm3_dir
+        else:
+            print("Warning: PROXMARK3_DIR environment variable points to the wrong folder, ignoring")
+
+    if os.name == 'nt':
+        print("Failed to find working 'pm3' command. On Windows, set the PROXMARK3_DIR environment variable to your Proxmark3 installation directory (e.g. D:\\Proxmark3).")
+        return None
+
+    # Get Homebrew installation (macOS/Linux)
+    brew_install = run_command(["brew", "--prefix", "proxmark3"])
+    if brew_install:
+        print("Found installation via Homebrew!")
+        return Path(brew_install)
+
+    # Get global installation
+    which_pm3 = run_command(["which", "pm3"])
+    if which_pm3:
+        which_pm3 = Path(which_pm3)
+        pm3_location = which_pm3.parent.parent
+        print(f"Found global installation ({pm3_location})!")
+        return pm3_location
+
+    # At this point, we've tried all the paths to find it
+    print("Failed to find working 'pm3' command. You can set the Proxmark3 directory via the 'PROXMARK3_DIR' environment variable.")
+    return None
+
+# Test a list of commands to see which one works
+# This lets us provide a list of OS-specific commands, test them
+# and figure out which one works on this specific computer
+# - Args: 
+#       - commandList: An array of OS-specific commands (sometimes including absolute installation path)
+#       - arguments: Optional arguments to be appended to the command. Useful for programs that don't exit on their own
+# This returns the command (string) of the first working command we encounter
+#
+def testCommands(directories, command, arguments = ""):
+    for directory in directories:
+        if directory is None:
+            continue
+
+        #OPTIONAL: add arguments such as "--help" to help identify programs that don't exit on their own
+        cmd_list = [directory+"/"+command] + ([arguments] if arguments else [])
+
+        #Test if this program works
+        print("Trying:", directory, end="...")
+        if run_command(cmd_list):
+            return Path(directory)
+    
+    return None #We didn't find any program that worked

--- a/library_checker.py
+++ b/library_checker.py
@@ -15,43 +15,16 @@ from rich.console import Console
 from pathlib import Path
 
 from parse import Tag, bytes_to_hex, BLOCKS_PER_SECTOR, TOTAL_SECTORS
+from categories import (
+    CATEGORY_MAP, MULTI_COLOR_MATERIAL_MAP, MATERIAL_MAP,
+    resolve_material, allowed_material_folders,
+)
 
 if not sys.version_info >= (3, 6):
   raise Exception("Python 3.6 or higher is required!")
 
 DUMP_SUFFIX = "-dump.bin"
 LIBRARY_ROOT = Path.cwd()
-
-# These map dicts map the 'filament_type' and 'detailed_filament_type' in the tags
-# to the names used in the library.
-
-CATEGORY_MAP = {
-  'PA-S': 'Support Material',
-  'PLA-S': 'Support Material',
-  'Support': 'Support Material',
-  'PVA': 'Support Material',
-  'ABS-S': 'Support Material',
-  'PETG-CF': 'PETG',
-  'TPU-AMS': 'TPU',
-  'ABS-GF': 'ABS',
-  'PLA-CF': 'PLA',
-  'PA-CF': 'PA',
-  'ASA-CF': 'ASA',
-  'ASA Aero': 'ASA',
-}
-
-MATERIAL_MAP = {
-  'Support for PA': ['Support for PA-PET'],
-  'Support For PA': ['Support for PA-PET'],
-  'Support G': ['Support for PA-PET'],
-  'Support W': ['Support for PLA-PETG'],
-  'Support for PLA': ['Support for PLA (New Version)', 'Support for PLA-PETG'],
-  'PETG-CF': ['PETG CF'],
-  'PETG HF': ['PETG Translucent'],
-  'PLA Basic': [ 'PLA Basic Gradient', 'PLA Silk Multi-Color'],
-  'PLA Silk': ['PLA Silk Multi-Color'],
-  'PLA': ['PLA Silk Multi-Color'],
-}
 
 def load_library(print_error=False, debug_color=None):
   library = {}
@@ -82,16 +55,13 @@ def load_library(print_error=False, debug_color=None):
         library[category][material][color_dir].append(color_hex)
 
     category = CATEGORY_MAP.get(category, category)
-    material_list = MATERIAL_MAP.get(material, material)
-    if not isinstance(material_list, list):
-      material_list = [material_list]
-    if material not in material_list:
-      material_list.append(material)
+    resolved = resolve_material(tag.data)
+    material_list = allowed_material_folders(tag.data)
     if debug_color:
       debug_color.print('\u2588', style=color_hex[0:7], end=' ')
       print(f'{color_hex} {file.relative_to(LIBRARY_ROOT)}')
     if print_error and (cat_dir != category or mat_dir not in material_list):
-      print(f"\t[!] {file.relative_to(LIBRARY_ROOT)} may be in the wrong directory! Should be in {category}/{material}")
+      print(f"\t[!] {file.relative_to(LIBRARY_ROOT)} may be in the wrong directory! Should be in {category}/{resolved}")
 
   if debug_color:
     print("Loading done")

--- a/repair.py
+++ b/repair.py
@@ -7,20 +7,14 @@
 
 import sys
 from pathlib import Path
-from Crypto.Protocol.KDF import HKDF
-from Crypto.Hash import SHA256
 
+from deriveKeys import kdf
 from parse import BYTES_PER_BLOCK, BLOCKS_PER_SECTOR, TOTAL_SECTORS, TOTAL_BYTES
 
 if not sys.version_info >= (3, 6):
   raise Exception("Python 3.6 or higher is required!")
 
 INVALID_KEYS = [b"\xFF" * 6, b"\x00" * 6]
-
-# Function copied from https://github.com/queengooborg/Bambu-Lab-RFID-Tag-Guide/blob/main/deriveKeys.py
-def kdf(uid):
-    salt = bytes([0x9a,0x75,0x9c,0xf2,0xc4,0xf7,0xca,0xff,0x22,0x2c,0xb9,0x76,0x9b,0x41,0xbc,0x96])
-    return HKDF(uid, 6, salt, SHA256, 16, context=b"RFID-A\0") + HKDF(uid, 6, salt, SHA256, 16, context=b"RFID-B\0")
 
 def sector_trailer_offset(sector):
     block_index = sector * BLOCKS_PER_SECTOR + 3
@@ -43,9 +37,9 @@ def repair_keys_in_place(path):
     print(f"\nFile : {path}")
     print(f"UID  : {uid.hex()}")
 
-    keys = kdf(uid)
-    if len(keys) != 32:
-        raise ValueError("KDF did not return 32 keys")
+    keys_a, keys_b = kdf(uid)
+    if len(keys_a) != 16 or len(keys_b) != 16:
+        raise ValueError("KDF did not return 16 keys for each of A and B")
 
     changes = 0
 
@@ -55,8 +49,8 @@ def repair_keys_in_place(path):
         key_a = dump[trailer : trailer + 6]
         key_b = dump[trailer + 10 : trailer + 16]
 
-        derived_a = keys[sector]
-        derived_b = keys[16 + sector]
+        derived_a = keys_a[sector]
+        derived_b = keys_b[sector]
 
         if is_invalid_key(key_a):
             dump[trailer : trailer + 6] = derived_a


### PR DESCRIPTION
Adds the foundational modules that other scripts depend on, bundled together so the PR is self-contained:

- `categories.py` — shared category/material lookup tables (maps `filament_type` values to top-level folder names, handles multi-colour material routing)
- `deriveKeys.py` — derives all 32 Mifare sector keys from a tag UID without requiring a sniffing session
- `lib/` — shared utilities for locating the Proxmark3 installation and running Proxmark3 commands
- `library_checker.py` — scans the library for tags in the wrong category/material folder, or colour folders containing more than one distinct hex colour (requires `categories.py`)
- `repair.py` — restores zeroed-out sector-trailer keys in a dump by re-deriving them from the UID (requires `deriveKeys.py`)
