### PR TITLE
Add colordb.py — Bambu Studio colour database helpers

### DIFF
--- a/colordb.py
+++ b/colordb.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+
+# Shared Bambu Studio colour database helpers.
+# Used by scanTag.py, fix_library.py, and menu.py.
+
+import json
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Database source locations
+# ---------------------------------------------------------------------------
+
+# Authoritative source — maintained by Bambu Lab alongside BambuStudio releases.
+COLOR_DB_URL = (
+    "https://raw.githubusercontent.com/bambulab/BambuStudio/master"
+    "/resources/profiles/BBL/filament/filaments_color_codes.json"
+)
+
+# Local fallback — present when Bambu Studio is installed on this machine.
+COLOR_DB_LOCAL_PATHS = [
+    Path(r"C:\Program Files\Bambu Studio\resources\profiles\BBL\filament\filaments_color_codes.json"),
+    Path(r"C:\Program Files (x86)\Bambu Studio\resources\profiles\BBL\filament\filaments_color_codes.json"),
+]
+
+# Bundled fallback — committed alongside this script; updated automatically
+# whenever a successful GitHub fetch is made.  Ensures the database is always
+# available even if the GitHub URL moves or the network is unreachable and
+# Bambu Studio is not installed.
+BUNDLED_DB_PATH = Path(__file__).parent.resolve() / 'filaments_color_codes.json'
+
+# Network timeout in seconds for the GitHub fetch.
+COLOR_DB_TIMEOUT = 5
+
+# fila_color_type values used throughout
+SINGLE_TYPE = '单色'
+MULTI_TYPES = {'渐变色', '多拼色'}
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def _parse_color_db(raw):
+    """Extract the list of entries from the parsed JSON (handles {"data":[...]} wrapper)."""
+    if isinstance(raw, dict):
+        return raw.get('data', [])
+    return raw  # already a plain list
+
+
+def load_color_database(silent=False):
+    """
+    Load the Bambu Studio filament colour database.
+
+    Tries GitHub first (always up to date); falls back to the locally
+    installed copy if the network is unavailable.  Returns a list of
+    colour entries, or an empty list if neither source is reachable.
+
+    Pass silent=True to suppress status messages.
+    """
+    def _msg(s):
+        if not silent:
+            print(s)
+
+    # --- 1. Try GitHub ---
+    try:
+        req = urllib.request.Request(
+            COLOR_DB_URL,
+            headers={'User-Agent': 'BambuRFIDTools/1.0 (Bambu-Research-Group)'},
+        )
+        with urllib.request.urlopen(req, timeout=COLOR_DB_TIMEOUT) as resp:
+            data = resp.read()
+        raw = json.loads(data.decode('utf-8'))
+        entries = _parse_color_db(raw)
+        if entries:
+            _msg(f"Loaded colour database from GitHub ({len(entries)} entries).")
+            # Refresh the bundled fallback so it stays current.
+            try:
+                BUNDLED_DB_PATH.write_bytes(data)
+            except OSError:
+                pass
+            return entries
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyboardInterrupt):
+        pass  # fall through to local copies
+
+    # --- 2. Fall back to local Bambu Studio installation ---
+    for path in COLOR_DB_LOCAL_PATHS:
+        if path.exists():
+            try:
+                with open(path, encoding='utf-8') as f:
+                    raw = json.load(f)
+                entries = _parse_color_db(raw)
+                if entries:
+                    _msg(f"(GitHub unreachable — using local Bambu Studio colour database, {len(entries)} entries.)")
+                    return entries
+            except Exception as e:
+                _msg(f"Warning: could not read local colour database at {path}: {e}")
+
+    # --- 3. Fall back to bundled copy shipped with the library ---
+    if BUNDLED_DB_PATH.exists():
+        try:
+            with open(BUNDLED_DB_PATH, encoding='utf-8') as f:
+                raw = json.load(f)
+            entries = _parse_color_db(raw)
+            if entries:
+                _msg(f"Warning: GitHub unreachable and Bambu Studio not found.")
+                _msg(f"  Using bundled colour database ({len(entries)} entries).")
+                _msg(f"  This may be out of date. Update by running with network access.")
+                return entries
+        except Exception as e:
+            _msg(f"Warning: could not read bundled colour database: {e}")
+
+    _msg("Warning: colour database not available — colour name must be entered manually.")
+    return []
+
+# ---------------------------------------------------------------------------
+# Colour distance helpers
+# ---------------------------------------------------------------------------
+
+def _hex_to_rgba(hex_color):
+    """Parse a hex colour string into an (R, G, B, A) tuple.
+    Accepts #RRGGBB (alpha assumed 255) or #RRGGBBAA."""
+    h = hex_color.lstrip('#')
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+    a = int(h[6:8], 16) if len(h) >= 8 else 255
+    return r, g, b, a
+
+
+def _color_distance(hex1, hex2):
+    """Euclidean RGBA distance between two hex colour strings (alpha included)."""
+    r1, g1, b1, a1 = _hex_to_rgba(hex1)
+    r2, g2, b2, a2 = _hex_to_rgba(hex2)
+    return ((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2 + (a1 - a2) ** 2) ** 0.5
+
+
+def distance_label(dist):
+    """Human-readable qualifier for an RGBA distance value."""
+    if dist < 15:
+        return "very close \u2014 likely a production batch variance"
+    if dist < 40:
+        return "approximate match \u2014 same colour family"
+    return "distant match \u2014 may be a genuinely different colour"
+
+# ---------------------------------------------------------------------------
+# Lookup functions
+# ---------------------------------------------------------------------------
+
+def lookup_color_name(tag_data, db):
+    """
+    Search the Bambu Studio colour database for entries matching this tag's
+    hex colour.
+
+    Filters by colour type (单色 / 渐变色 / 多拼色) using filament_color_count so
+    that single-colour tags never match gradient entries and vice versa.
+
+    For multi-colour tags, filament_color is slash-joined ("#720062FF / #3A913FFF");
+    ALL of the tag's colours must appear in the database entry.
+
+    Returns (exact_name, candidates) where:
+      exact_name  -- English name when material type AND hex both matched, else None
+      candidates  -- list of (name, fila_type) for entries where only hex matched
+    """
+    if not db:
+        return None, []
+
+    target_colors = [c.strip().upper() for c in tag_data['filament_color'].split('/')]
+    target_type   = tag_data['detailed_filament_type']
+    is_multi      = tag_data.get('filament_color_count', 1) > 1
+
+    exact_name = None
+    candidates = []
+
+    for entry in db:
+        entry_color_type = entry.get('fila_color_type', '')
+        if is_multi and entry_color_type not in MULTI_TYPES:
+            continue
+        if not is_multi and entry_color_type != SINGLE_TYPE:
+            continue
+
+        colors = [c.upper() for c in entry.get('fila_color', [])]
+        if not all(tc in colors for tc in target_colors):
+            continue
+
+        name = entry.get('fila_color_name', {}).get('en', '').strip()
+        if not name:
+            continue
+
+        if entry.get('fila_type') == target_type:
+            if exact_name is None:
+                exact_name = name
+        else:
+            candidates.append((name, entry.get('fila_type', '?')))
+
+    return exact_name, candidates
+
+
+def find_nearest_color(tag_data, db):
+    """
+    Find the closest colour in the database by Euclidean RGBA distance.
+
+    Uses only the first colour of multi-colour tags (distance is a scalar).
+    Prefers entries whose fila_type matches the tag's detailed_filament_type.
+
+    Returns (name, matched_hex, distance, fila_type, is_exact_type).
+    """
+    if not db:
+        return None, None, float('inf'), None, False
+
+    target_color = tag_data['filament_color'].split('/')[0].strip().upper()
+    target_type  = tag_data['detailed_filament_type']
+    is_multi     = tag_data.get('filament_color_count', 1) > 1
+
+    best_exact = (None, None, float('inf'), None)
+    best_any   = (None, None, float('inf'), None)
+
+    for entry in db:
+        entry_color_type = entry.get('fila_color_type', '')
+        if is_multi and entry_color_type not in MULTI_TYPES:
+            continue
+        if not is_multi and entry_color_type != SINGLE_TYPE:
+            continue
+
+        name = entry.get('fila_color_name', {}).get('en', '').strip()
+        if not name:
+            continue
+
+        ftype = entry.get('fila_type', '')
+
+        for hex_c in entry.get('fila_color', []):
+            try:
+                dist = _color_distance(target_color, hex_c.upper())
+            except Exception:
+                continue
+            if ftype == target_type and dist < best_exact[2]:
+                best_exact = (name, hex_c, dist, ftype)
+            if dist < best_any[2]:
+                best_any = (name, hex_c, dist, ftype)
+
+    if best_exact[0] is not None:
+        name, hex_c, dist, ftype = best_exact
+        return name, hex_c, dist, ftype, True
+    if best_any[0] is not None:
+        name, hex_c, dist, ftype = best_any
+        return name, hex_c, dist, ftype, False
+    return None, None, float('inf'), None, False

--- a/filaments_color_codes.json
+++ b/filaments_color_codes.json
@@ -1,0 +1,7019 @@
+{
+    "data": [
+        {
+            "fila_color_code": "10300",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Orange",
+                "sv": "Orange",
+                "pt": "Laranja",
+                "ko": "오렌지",
+                "ja": "オレンジ",
+                "en": "Orange",
+                "it": "Arancione",
+                "fr": "Orange",
+                "hu": "Narancssárga",
+                "zh": "橙色",
+                "nl": "Oranje",
+                "es": "Naranja"
+            },
+            "fila_color": [
+                "#FF6A13FF"
+            ]
+        },
+        {
+            "fila_color_code": "10301",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Kürbis-Orange",
+                "sv": "Pumpaorange",
+                "pt": "Abóbora Laranja",
+                "ko": "펌프킨 오렌지",
+                "ja": "パンプキン オレンジ",
+                "en": "Pumpkin Orange",
+                "it": "Arancione zucca",
+                "fr": "Orange citrouille",
+                "hu": "Sütőtök",
+                "zh": "南瓜橙",
+                "nl": "Pompoenoranje",
+                "es": "Naranja calabaza"
+            },
+            "fila_color": [
+                "#FF9016FF"
+            ]
+        },
+        {
+            "fila_color_code": "10602",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Blau-Grau",
+                "sv": "Blågrå",
+                "pt": "Azul-Cinza",
+                "ko": "블루 그레이",
+                "ja": "ブルー グレー",
+                "en": "Blue Gray",
+                "it": "Grigio blu",
+                "fr": "Bleu gris",
+                "hu": "Kékesszürke",
+                "zh": "蓝灰",
+                "nl": "Blauwgrijs",
+                "es": "Gris azulado"
+            },
+            "fila_color": [
+                "#5B6579FF"
+            ]
+        },
+        {
+            "fila_color_code": "10604",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Kobaltblau",
+                "sv": "Koboltblå",
+                "pt": "Azul-cobalto",
+                "ko": "코발트 블루",
+                "ja": "コバルト ブルー",
+                "en": "Cobalt Blue",
+                "it": "Blu cobalto",
+                "fr": "Bleu cobalt",
+                "hu": "Kobaltkék",
+                "zh": "钴蓝色",
+                "nl": "Kobaltblauw",
+                "es": "Azul cobalto"
+            },
+            "fila_color": [
+                "#0056B8FF"
+            ]
+        },
+        {
+            "fila_color_code": "10605",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Türkis",
+                "sv": "Turkos",
+                "pt": "Turquesa",
+                "ko": "터쿼이즈",
+                "ja": "ターコイズ",
+                "en": "Turquoise",
+                "it": "Turchese",
+                "fr": "Turquoise",
+                "hu": "Türkiz",
+                "zh": "松石绿",
+                "nl": "Turkoois",
+                "es": "Turquesa"
+            },
+            "fila_color": [
+                "#00B1B7FF"
+            ]
+        },
+        {
+            "fila_color_code": "10603",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Cyan",
+                "sv": "Cyan",
+                "pt": "Ciano",
+                "ko": "시안",
+                "ja": "シアン",
+                "en": "Cyan",
+                "it": "Ciano",
+                "fr": "Cyan",
+                "hu": "Cián",
+                "zh": "青色",
+                "nl": "Cyaan",
+                "es": "Cian"
+            },
+            "fila_color": [
+                "#0086D6FF"
+            ]
+        },
+        {
+            "fila_color_code": "10601",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#0A2989FF"
+            ]
+        },
+        {
+            "fila_color_code": "10103",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#8E9089FF"
+            ]
+        },
+        {
+            "fila_color_code": "10102",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Silber",
+                "sv": "Silver",
+                "pt": "Prateado",
+                "ko": "실버",
+                "ja": "シルバー",
+                "en": "Silver",
+                "it": "Argento",
+                "fr": "Argenté",
+                "hu": "Ezüst",
+                "zh": "银色",
+                "nl": "Zilver",
+                "es": "Plateado"
+            },
+            "fila_color": [
+                "#A6A9AAFF"
+            ]
+        },
+        {
+            "fila_color_code": "10104",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Hellgrau",
+                "sv": "Ljusgrå",
+                "pt": "Cinza-claro",
+                "ko": "라이트 그레이",
+                "ja": "ライト グレー",
+                "en": "Light Gray",
+                "it": "Grigio chiaro",
+                "fr": "Gris clair",
+                "hu": "Világosszürke",
+                "zh": "浅灰",
+                "nl": "Lichtgrijs",
+                "es": "Gris claro"
+            },
+            "fila_color": [
+                "#D1D3D5FF"
+            ]
+        },
+        {
+            "fila_color_code": "10105",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Dunkelgrau",
+                "sv": "Mörkgrå",
+                "pt": "Cinza-escuro",
+                "ko": "다크 그레이",
+                "ja": "ダーク グレー",
+                "en": "Dark Gray",
+                "it": "Grigio scuro",
+                "fr": "Gris foncé",
+                "hu": "Sötétszürke",
+                "zh": "深灰",
+                "nl": "Donkergrijs",
+                "es": "Gris oscuro"
+            },
+            "fila_color": [
+                "#545454FF"
+            ]
+        },
+        {
+            "fila_color_code": "10500",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "墨绿",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#164B35FF"
+            ]
+        },
+        {
+            "fila_color_code": "10502",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Mistelzweig-Grün",
+                "sv": "Mistelgrön",
+                "pt": "Mistletoe Green",
+                "ko": "미슬토 그린",
+                "ja": "ミスルトー グリーン",
+                "en": "Mistletoe Green",
+                "it": "Verde vischio",
+                "fr": "Vert gui",
+                "hu": "Fagyöngyzöld",
+                "zh": "圣诞绿",
+                "nl": "Maretakgroen",
+                "es": "Verde muérdago"
+            },
+            "fila_color": [
+                "#3F8E43FF"
+            ]
+        },
+        {
+            "fila_color_code": "10503",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Hellgrün",
+                "sv": "Ljusgrön",
+                "pt": "Verde Brilhante",
+                "ko": "브라이트 그린",
+                "ja": "ブライト グリーン",
+                "en": "Bright Green",
+                "it": "Verde brillante",
+                "fr": "Vert vif",
+                "hu": "Világoszöld",
+                "zh": "苹果绿",
+                "nl": "Felgroen",
+                "es": "Verde brillante"
+            },
+            "fila_color": [
+                "#BECF00FF"
+            ]
+        },
+        {
+            "fila_color_code": "10501",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Bambusgrün",
+                "sv": "Bambugrön",
+                "pt": "Verde-bambu",
+                "ko": "뱀부 그린",
+                "ja": "バンブー グリーン",
+                "en": "Bambu Green",
+                "it": "Verde bambù",
+                "fr": "Vert bambou",
+                "hu": "Bambu-zöld",
+                "zh": "拓竹绿",
+                "nl": "Bamboegroen",
+                "es": "Verde bambú"
+            },
+            "fila_color": [
+                "#00AE42FF"
+            ]
+        },
+        {
+            "fila_color_code": "10101",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "10900",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Arktisches Flüstern",
+                "sv": "Arktisk viskning",
+                "pt": "Arctic Whisper",
+                "ko": "아크틱 위스퍼",
+                "ja": "アークティック ウィスパー",
+                "en": "Arctic Whisper",
+                "it": "Arctic Whisper",
+                "fr": "Murmure arctique",
+                "hu": "Sarkköri suttogás",
+                "zh": "蓝白渐变",
+                "nl": "Vleugje noordpool",
+                "es": "Susurro ártico"
+            },
+            "fila_color": [
+                "#FFFFFFFF",
+                "#9CDBD9FF"
+            ]
+        },
+        {
+            "fila_color_code": "10901",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Sonnenbrise",
+                "sv": "Solbris",
+                "pt": "Brisa Solar",
+                "ko": "솔라 브리즈",
+                "ja": "ソーラー ブリーズ",
+                "en": "Solar Breeze",
+                "it": "Solar Breeze",
+                "fr": "Brise solaire",
+                "hu": "Napszellő",
+                "zh": "红白渐变",
+                "nl": "Zonnebries",
+                "es": "Brisa solar"
+            },
+            "fila_color": [
+                "#E94B3CFF",
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "10902",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Meer und Wiese",
+                "sv": "Ocean till äng",
+                "pt": "Ocean to Meadow",
+                "ko": "오션에서 메도우로",
+                "ja": "オーシャン トゥ メドウ",
+                "en": "Ocean to Meadow",
+                "it": "Azzurro/verde con gradazione",
+                "fr": "Océan à Prairie",
+                "hu": "Óceántól a rétig",
+                "zh": "蓝绿渐变",
+                "nl": "Van oceaanblauw naar weidegroen",
+                "es": "Del océano a la pradera"
+            },
+            "fila_color": [
+                "#307FE2FF",
+                "#54FF9BFF"
+            ]
+        },
+        {
+            "fila_color_code": "10903",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Zitrus-Pink",
+                "sv": "Rosa citrus",
+                "pt": "Pink Citrus",
+                "ko": "핑크 시트러스",
+                "ja": "ピンク シトラス",
+                "en": "Pink Citrus",
+                "it": "Rosa citrus",
+                "fr": "Agrume rose",
+                "hu": "Rózsaszín-citrus",
+                "zh": "霞光粉",
+                "nl": "Roze citrus",
+                "es": "Rosa cítrico"
+            },
+            "fila_color": [
+                "#F78F77FF",
+                "#E4505AFF"
+            ]
+        },
+        {
+            "fila_color_code": "10904",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Minze-Limette",
+                "sv": "Mintlime",
+                "pt": "Menta-lima",
+                "ko": "민트 라임",
+                "ja": "ミント ライム",
+                "en": "Mint Lime",
+                "it": "Lime menta",
+                "fr": "Menthe citron vert",
+                "hu": "Menta-lime",
+                "zh": "青柠绿",
+                "nl": "Muntlimoen",
+                "es": "Lima menta"
+            },
+            "fila_color": [
+                "#4EC939FF",
+                "#B6FF43FF"
+            ]
+        },
+        {
+            "fila_color_code": "10905",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Blaubeere-Bubblegum",
+                "sv": "Blåbärsbubbelgum",
+                "pt": "Chiclete de Mirtilo",
+                "ko": "블루베리 버블검",
+                "ja": "ブルーベリー バブルガム",
+                "en": "Blueberry Bubblegum",
+                "it": "Mirtillo",
+                "fr": "Chewing-gum myrtilles",
+                "hu": "Áfonyás rágógumi",
+                "zh": "泡泡紫",
+                "nl": "Bosbessenkauwgum",
+                "es": "Chicle de arándano"
+            },
+            "fila_color": [
+                "#6FCAEFFF",
+                "#8573DDFF"
+            ]
+        },
+        {
+            "fila_color_code": "10906",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Leuchtende Abenddämmerung",
+                "sv": "Skymningsljus",
+                "pt": "Brilho do Crepúsculo",
+                "ko": "더스크 글래어",
+                "ja": "ダスク グレア",
+                "en": "Dusk Glare",
+                "it": "Dusk Glare",
+                "fr": "Éclat crépusculaire",
+                "hu": "Alkonyati csillámlás",
+                "zh": "日落橙",
+                "nl": "Schemerlicht",
+                "es": "Resplandor del crepúsculo"
+            },
+            "fila_color": [
+                "#CE4406FF",
+                "#ED9558FF"
+            ]
+        },
+        {
+            "fila_color_code": "10907",
+            "fila_id": "GFA00",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Zuckerwatten-Wolke",
+                "sv": "Sockervaddsmoln",
+                "pt": "Cotton Candy Cloud",
+                "ko": "코튼 캔디 클라우드",
+                "ja": "コットン キャンディ クラウド",
+                "en": "Cotton Candy Cloud",
+                "it": "Zucchero filato",
+                "fr": "Nuage de barbe à papa",
+                "hu": "Vattacukorfelhő",
+                "zh": "多巴胺（粉蓝渐变）",
+                "nl": "Suikerspinwolk",
+                "es": "Nube de algodón de azúcar"
+            },
+            "fila_color": [
+                "#8EC9E9FF",
+                "#E7C1D5FF"
+            ]
+        },
+        {
+            "fila_color_code": "10800",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Braun",
+                "sv": "Brun",
+                "pt": "Marrom",
+                "ko": "브라운",
+                "ja": "ブラウン",
+                "en": "Brown",
+                "it": "Marrone",
+                "fr": "Marron",
+                "hu": "Barna",
+                "zh": "棕色",
+                "nl": "Bruin",
+                "es": "Marrón"
+            },
+            "fila_color": [
+                "#9D432CFF"
+            ]
+        },
+        {
+            "fila_color_code": "10802",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Kakaobraun",
+                "sv": "Kakaobrun",
+                "pt": "Cacau Marrom",
+                "ko": "코코아 브라운",
+                "ja": "ココア ブラウン",
+                "en": "Cocoa Brown",
+                "it": "Marrone cacao",
+                "fr": "Marron cacao",
+                "hu": "Kakaóbarna",
+                "zh": "可可棕",
+                "nl": "Chocoladebruin",
+                "es": "Marrón cacao"
+            },
+            "fila_color": [
+                "#6F5034FF"
+            ]
+        },
+        {
+            "fila_color_code": "10201",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Beige",
+                "sv": "Beige",
+                "pt": "Bege",
+                "ko": "베이지",
+                "ja": "ベージュ",
+                "en": "Beige",
+                "it": "Beige",
+                "fr": "Beige",
+                "hu": "Bézs",
+                "zh": "杏色",
+                "nl": "Beige",
+                "es": "Beis"
+            },
+            "fila_color": [
+                "#F7E6DEFF"
+            ]
+        },
+        {
+            "fila_color_code": "10203",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Pink",
+                "sv": "Rosa",
+                "pt": "Rosa",
+                "ko": "핑크",
+                "ja": "ピンク",
+                "en": "Pink",
+                "it": "Rosa",
+                "fr": "Rose",
+                "hu": "Rózsaszín",
+                "zh": "粉色",
+                "nl": "Roze",
+                "es": "Rosa"
+            },
+            "fila_color": [
+                "#F55A74FF"
+            ]
+        },
+        {
+            "fila_color_code": "10701",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Indigo-Violett",
+                "sv": "Indigolila",
+                "pt": "Indigo Purple",
+                "ko": "인디고 퍼플",
+                "ja": "インディゴ パープル",
+                "en": "Indigo Purple",
+                "it": "Viola indaco",
+                "fr": "Violet indigo",
+                "hu": "Indigólila",
+                "zh": "绀紫色",
+                "nl": "Indigopaars",
+                "es": "Púrpura índigo"
+            },
+            "fila_color": [
+                "#482960FF"
+            ]
+        },
+        {
+            "fila_color_code": "10700",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Lila",
+                "sv": "Lila",
+                "pt": "Roxo",
+                "ko": "퍼플",
+                "ja": "パープル",
+                "en": "Purple",
+                "it": "Viola",
+                "fr": "Violet",
+                "hu": "Lila",
+                "zh": "紫色",
+                "nl": "Paars",
+                "es": "Púrpura"
+            },
+            "fila_color": [
+                "#5E43B7FF"
+            ]
+        },
+        {
+            "fila_color_code": "10202",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Magenta",
+                "sv": "Magenta",
+                "pt": "Magenta",
+                "ko": "마젠타",
+                "ja": "マゼンタ",
+                "en": "Magenta",
+                "it": "Magenta",
+                "fr": "Magenta",
+                "hu": "Magenta",
+                "zh": "品红",
+                "nl": "Magenta",
+                "es": "Magenta"
+            },
+            "fila_color": [
+                "#EC008CFF"
+            ]
+        },
+        {
+            "fila_color_code": "10200",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#C12E1FFF"
+            ]
+        },
+        {
+            "fila_color_code": "10205",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Kastanienrot",
+                "sv": "Rödbrun",
+                "pt": "Maroon Red",
+                "ko": "마룬 레드",
+                "ja": "マルーン レッド",
+                "en": "Maroon Red",
+                "it": "Rosso bordeaux",
+                "fr": "Rouge marron",
+                "hu": "Gesztenyés vörös",
+                "zh": "胭脂红",
+                "nl": "Kastanjerood",
+                "es": "Rojo granate"
+            },
+            "fila_color": [
+                "#9D2235FF"
+            ]
+        },
+        {
+            "fila_color_code": "10204",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Heißes Pink",
+                "sv": "Neonrosa",
+                "pt": "Rosa-choque",
+                "ko": "핫핑크",
+                "ja": "ホット ピンク",
+                "en": "Hot Pink",
+                "it": "Fucsia",
+                "fr": "Rose vif",
+                "hu": "Forró rózsaszín",
+                "zh": "桃红色",
+                "nl": "Felroze",
+                "es": "Rosa fucsia"
+            },
+            "fila_color": [
+                "#F5547CFF"
+            ]
+        },
+        {
+            "fila_color_code": "10100",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Jade-Weiß",
+                "sv": "Jadevit",
+                "pt": "Jade Branco",
+                "ko": "제이드 화이트",
+                "ja": "ジェイド ホワイト",
+                "en": "Jade White",
+                "it": "Bianco giada",
+                "fr": "Blanc de jade",
+                "hu": "Jádefehér",
+                "zh": "玉石白",
+                "nl": "Jadewit",
+                "es": "Blanco jade"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "10400",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#F4EE2AFF"
+            ]
+        },
+        {
+            "fila_color_code": "10402",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Sonnenblumen-Gelb",
+                "sv": "Solrosgul",
+                "pt": "Girassol Amarelo",
+                "ko": "썬플라워 옐로우",
+                "ja": "サンフラワー イエロー",
+                "en": "Sunflower Yellow",
+                "it": "Giallo girasole",
+                "fr": "Jaune tournesol",
+                "hu": "Napraforgósárga",
+                "zh": "暖黄色",
+                "nl": "Zonnebloemgeel",
+                "es": "Amarillo girasol"
+            },
+            "fila_color": [
+                "#FEC600FF"
+            ]
+        },
+        {
+            "fila_color_code": "10801",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Bronze",
+                "sv": "Brons",
+                "pt": "Bronze",
+                "ko": "브론즈",
+                "ja": "ブロンズ",
+                "en": "Bronze",
+                "it": "Bronzo",
+                "fr": "Bronze",
+                "hu": "Bronz",
+                "zh": "青铜",
+                "nl": "Bronskleurig",
+                "es": "Bronce"
+            },
+            "fila_color": [
+                "#847D48FF"
+            ]
+        },
+        {
+            "fila_color_code": "10401",
+            "fila_id": "GFA00",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Basic",
+            "fila_color_name": {
+                "de": "Gold",
+                "sv": "Guld",
+                "pt": "Dourado",
+                "ko": "골드",
+                "ja": "ゴールド",
+                "en": "Gold",
+                "it": "Oro",
+                "fr": "Doré",
+                "hu": "Arany",
+                "zh": "金色",
+                "nl": "Goud",
+                "es": "Dorado"
+            },
+            "fila_color": [
+                "#E4BD68FF"
+            ]
+        },
+        {
+            "fila_color_code": "11300",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Mandarine-Orange",
+                "sv": "Mandarinorange",
+                "pt": "Tangerina",
+                "ko": "만다린 오렌지",
+                "ja": "マンダリン オレンジ",
+                "en": "Mandarin Orange",
+                "it": "Arancio mandarino",
+                "fr": "Mandarine",
+                "hu": "Mandarinsárga",
+                "zh": "橘橙",
+                "nl": "Mandarijnoranje",
+                "es": "Naranja Mandarina"
+            },
+            "fila_color": [
+                "#F99963FF"
+            ]
+        },
+        {
+            "fila_color_code": "11603",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Himmelblau",
+                "sv": "Himmelsblå",
+                "pt": "Azul-celeste",
+                "ko": "스카이 블루",
+                "ja": "スカイ ブルー",
+                "en": "Sky Blue",
+                "it": "Azzurro cielo",
+                "fr": "Bleu ciel",
+                "hu": "Égszínkék",
+                "zh": "天蓝色",
+                "nl": "Hemelsblauw",
+                "es": "Azul cielo"
+            },
+            "fila_color": [
+                "#56B7E6FF"
+            ]
+        },
+        {
+            "fila_color_code": "11600",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Marineblau",
+                "sv": "Marinblå",
+                "pt": "Azul-marinho",
+                "ko": "마린 블루",
+                "ja": "マリン ブルー",
+                "en": "Marine Blue",
+                "it": "Blu marino",
+                "fr": "Bleu marine",
+                "hu": "Tengerkék",
+                "zh": "海蓝",
+                "nl": "Marineblauw",
+                "es": "Azul marino"
+            },
+            "fila_color": [
+                "#0078BFFF"
+            ]
+        },
+        {
+            "fila_color_code": "11601",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Eisblau",
+                "sv": "Isblå",
+                "pt": "Azul-gelo",
+                "ko": "아이스 블루",
+                "ja": "アイス ブルー",
+                "en": "Ice Blue",
+                "it": "Blu ghiaccio",
+                "fr": "Bleu glacier",
+                "hu": "Jégkék",
+                "zh": "冰蓝",
+                "nl": "IJsblauw",
+                "es": "Azul hielo"
+            },
+            "fila_color": [
+                "#A3D8E1FF"
+            ]
+        },
+        {
+            "fila_color_code": "11602",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Dunkelblau",
+                "sv": "Mörkblå",
+                "pt": "Azul-escuro",
+                "ko": "다크 블루",
+                "ja": "ダーク ブルー",
+                "en": "Dark Blue",
+                "it": "Blu scuro",
+                "fr": "Bleu foncé",
+                "hu": "Sötétkék",
+                "zh": "暗夜蓝",
+                "nl": "Donkerblauw",
+                "es": "Azul oscuro"
+            },
+            "fila_color": [
+                "#042F56FF"
+            ]
+        },
+        {
+            "fila_color_code": "11104",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Nardo-Grau",
+                "sv": "Nardogrå",
+                "pt": "Nardo Gray",
+                "ko": "나르도 그레이",
+                "ja": "ナルド グレイ",
+                "en": "Nardo Gray",
+                "it": "Grigio Nardo",
+                "fr": "Gris nardo",
+                "hu": "Matt szürke",
+                "zh": "枪灰色",
+                "nl": "Nardogrijs",
+                "es": "Gris nardo"
+            },
+            "fila_color": [
+                "#757575FF"
+            ]
+        },
+        {
+            "fila_color_code": "11102",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Aschgrau",
+                "sv": "Askgrå",
+                "pt": "Ash Gray",
+                "ko": "애쉬 그레이",
+                "ja": "アッシュ グレー",
+                "en": "Ash Gray",
+                "it": "Grigio cenere",
+                "fr": "Gris cendré",
+                "hu": "Hamuszürke",
+                "zh": "岩石灰",
+                "nl": "Asgrijs",
+                "es": "Gris ceniza"
+            },
+            "fila_color": [
+                "#9B9EA0FF"
+            ]
+        },
+        {
+            "fila_color_code": "11502",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Apfelgrün",
+                "sv": "Äppelgrön",
+                "pt": "Maçã-Verde",
+                "ko": "애플 그린",
+                "ja": "アップル グリーン",
+                "en": "Apple Green",
+                "it": "Verde mela",
+                "fr": "Vert pomme",
+                "hu": "Almazöld",
+                "zh": "果绿色",
+                "nl": "Appelgroen",
+                "es": "Verde manzana"
+            },
+            "fila_color": [
+                "#C2E189FF"
+            ]
+        },
+        {
+            "fila_color_code": "11500",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Grasgrün",
+                "sv": "Gräsgrön",
+                "pt": "Grama Verde",
+                "ko": "그래스 그린",
+                "ja": "グラス グリーン",
+                "en": "Grass Green",
+                "it": "Verde prato",
+                "fr": "Vert herbacé",
+                "hu": "Fűzöld",
+                "zh": "草绿",
+                "nl": "Grasgroen",
+                "es": "Verde hierba"
+            },
+            "fila_color": [
+                "#61C680FF"
+            ]
+        },
+        {
+            "fila_color_code": "11501",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Dunkelgrün",
+                "sv": "Mörkgrön",
+                "pt": "Verde-escuro",
+                "ko": "다크 그린",
+                "ja": "ダーク グリーン",
+                "en": "Dark Green",
+                "it": "Verde scuro",
+                "fr": "Vert foncé",
+                "hu": "Sötétzöld",
+                "zh": "暗夜绿",
+                "nl": "Donkergroen",
+                "es": "Verde oscuro"
+            },
+            "fila_color": [
+                "#68724DFF"
+            ]
+        },
+        {
+            "fila_color_code": "11101",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Kohlschwarz",
+                "sv": "Kolsvart",
+                "pt": "Carvão",
+                "ko": "차콜",
+                "ja": "チャコール",
+                "en": "Charcoal",
+                "it": "Carbone",
+                "fr": "Anthracite",
+                "hu": "Faszén",
+                "zh": "炭黑",
+                "nl": "Donkergrijs",
+                "es": "Carbón"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "11802",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Dunkel-Schokoladenbraun",
+                "sv": "Mörk choklad",
+                "pt": "Chocolate-escuro",
+                "ko": "다크 초콜릿",
+                "ja": "ダーク チョコレート",
+                "en": "Dark Chocolate",
+                "it": "Cioccolato",
+                "fr": "Chocolat noir",
+                "hu": "Étcsokoládé",
+                "zh": "深棕色",
+                "nl": "Donkerchocoladebruin",
+                "es": "Chocolate oscuro"
+            },
+            "fila_color": [
+                "#4D3324FF"
+            ]
+        },
+        {
+            "fila_color_code": "11800",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Milchkaffee-Braun",
+                "sv": "Lattebrun",
+                "pt": "Café com Leite",
+                "ko": "라떼 브라운",
+                "ja": "ラテ ブラウン",
+                "en": "Latte Brown",
+                "it": "Caffelatte",
+                "fr": "Marron latte",
+                "hu": "Lattebarna",
+                "zh": "拿铁褐",
+                "nl": "Lattebruin",
+                "es": "Marrón Latte"
+            },
+            "fila_color": [
+                "#D3B7A7FF"
+            ]
+        },
+        {
+            "fila_color_code": "11801",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Dunkelbraun",
+                "sv": "Mörkbrun",
+                "pt": "Marrom-escuro",
+                "ko": "다크 브라운",
+                "ja": "ダーク ブラウン",
+                "en": "Dark Brown",
+                "it": "Marrone scuro",
+                "fr": "Marron foncé",
+                "hu": "Sötétbarna",
+                "zh": "暗夜棕",
+                "nl": "Donkerbruin",
+                "es": "Marrón oscuro"
+            },
+            "fila_color": [
+                "#7D6556FF"
+            ]
+        },
+        {
+            "fila_color_code": "11803",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Karamell",
+                "sv": "Kola",
+                "pt": "Caramelo",
+                "ko": "캐러멜",
+                "ja": "キャラメル",
+                "en": "Caramel",
+                "it": "Caramello",
+                "fr": "Caramel",
+                "hu": "Karamella",
+                "zh": "沙棕色",
+                "nl": "Karamel",
+                "es": "Caramelo"
+            },
+            "fila_color": [
+                "#AE835BFF"
+            ]
+        },
+        {
+            "fila_color_code": "11201",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Sakura-Pink",
+                "sv": "Körsbärsrosa",
+                "pt": "Sakura Rosa",
+                "ko": "사쿠라 핑크",
+                "ja": "サクラ ピンク",
+                "en": "Sakura Pink",
+                "it": "Rosa sakura",
+                "fr": "Rose sakura",
+                "hu": "Szakurarózsaszín",
+                "zh": "樱花粉",
+                "nl": "Sakura-roze",
+                "es": "Rosa sakura"
+            },
+            "fila_color": [
+                "#E8AFCFFF"
+            ]
+        },
+        {
+            "fila_color_code": "11700",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Flieder-Violett",
+                "sv": "Syrenlila",
+                "pt": "Lilás Roxo",
+                "ko": "라일락 퍼플",
+                "ja": "ライラック パープル",
+                "en": "Lilac Purple",
+                "it": "Lilla",
+                "fr": "Violet lilas",
+                "hu": "Ibolya",
+                "zh": "丁香紫",
+                "nl": "Lilapaars",
+                "es": "Púrpura lila"
+            },
+            "fila_color": [
+                "#AE96D4FF"
+            ]
+        },
+        {
+            "fila_color_code": "11200",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Scharlachrot",
+                "sv": "Scharlakansröd",
+                "pt": "Vermelho Escarlate",
+                "ko": "스칼렛 레드",
+                "ja": "スカーレット レッド",
+                "en": "Scarlet Red",
+                "it": "Rosso scarlatto",
+                "fr": "Rouge écarlate",
+                "hu": "Skarlátvörös",
+                "zh": "猩红",
+                "nl": "Scharlakenrood",
+                "es": "Rojo escarlata"
+            },
+            "fila_color": [
+                "#DE4343FF"
+            ]
+        },
+        {
+            "fila_color_code": "11203",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Terrakotta",
+                "sv": "Terrakotta",
+                "pt": "Terracota",
+                "ko": "테라코타",
+                "ja": "テラコッタ",
+                "en": "Terracotta",
+                "it": "Terracotta",
+                "fr": "Terre cuite",
+                "hu": "Terrakotta",
+                "zh": "砖红色",
+                "nl": "Terracotta",
+                "es": "Terracota"
+            },
+            "fila_color": [
+                "#B15533FF"
+            ]
+        },
+        {
+            "fila_color_code": "11204",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Pflaume",
+                "sv": "Plommon",
+                "pt": "Ameixa",
+                "ko": "플럼",
+                "ja": "プラム",
+                "en": "Plum",
+                "it": "Prugna",
+                "fr": "Prune",
+                "hu": "Szilva",
+                "zh": "莓果紫",
+                "nl": "Pruim",
+                "es": "Ciruela"
+            },
+            "fila_color": [
+                "#950051FF"
+            ]
+        },
+        {
+            "fila_color_code": "11202",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Dunkelrot",
+                "sv": "Mörkröd",
+                "pt": "Vermelho-escuro",
+                "ko": "다크 레드",
+                "ja": "ダーク レッド",
+                "en": "Dark Red",
+                "it": "Rosso scuro",
+                "fr": "Rouge foncé",
+                "hu": "Sötétvörös",
+                "zh": "暗夜红",
+                "nl": "Donkerrood",
+                "es": "Rojo oscuro"
+            },
+            "fila_color": [
+                "#BB3D43FF"
+            ]
+        },
+        {
+            "fila_color_code": "11100",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Elfenbeinweiß",
+                "sv": "Elfenbensvit",
+                "pt": "Branco Marfim",
+                "ko": "아이보리 화이트",
+                "ja": "アイボリー ホワイト",
+                "en": "Ivory White",
+                "it": "Bianco avorio",
+                "fr": "Blanc ivoire",
+                "hu": "Elefántcsontfehér",
+                "zh": "象牙白",
+                "nl": "Ivoorwit",
+                "es": "Blanco marfil"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "11103",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Knochenweiß",
+                "sv": "Benvit",
+                "pt": "Bone White",
+                "ko": "본 화이트",
+                "ja": "ボーン ホワイト",
+                "en": "Bone White",
+                "it": "Bianco osso",
+                "fr": "Blanc os",
+                "hu": "Csontfehér",
+                "zh": "骨白",
+                "nl": "Beenwit",
+                "es": "Blanco hueso"
+            },
+            "fila_color": [
+                "#CBC6B8FF"
+            ]
+        },
+        {
+            "fila_color_code": "11400",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Zitronengelb",
+                "sv": "Citrongul",
+                "pt": "Amarelo-limão",
+                "ko": "레몬 옐로우",
+                "ja": "レモン イエロー",
+                "en": "Lemon Yellow",
+                "it": "Giallo limone",
+                "fr": "Jaune citron",
+                "hu": "Citromsárga",
+                "zh": "柠檬黄",
+                "nl": "Citroengeel",
+                "es": "Amarillo limón"
+            },
+            "fila_color": [
+                "#F7D959FF"
+            ]
+        },
+        {
+            "fila_color_code": "11401",
+            "fila_id": "GFA01",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Matte",
+            "fila_color_name": {
+                "de": "Wüstenbraun",
+                "sv": "Ökenbrun",
+                "pt": "Desert Tan",
+                "ko": "데저트 탄",
+                "ja": "デザート タン",
+                "en": "Desert Tan",
+                "it": "Sabbia",
+                "fr": "Brun clair du désert",
+                "hu": "Sivatagi cser",
+                "zh": "沙漠黄",
+                "nl": "Woestijnbruin",
+                "es": "Arena del desierto"
+            },
+            "fila_color": [
+                "#E8DBB7FF"
+            ]
+        },
+        {
+            "fila_color_code": "13601",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#147BD1FF"
+            ]
+        },
+        {
+            "fila_color_code": "13104",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Silber",
+                "sv": "Silver",
+                "pt": "Prateado",
+                "ko": "실버",
+                "ja": "シルバー",
+                "en": "Silver",
+                "it": "Argento",
+                "fr": "Argenté",
+                "hu": "Ezüst",
+                "zh": "银色",
+                "nl": "Zilver",
+                "es": "Plateado"
+            },
+            "fila_color": [
+                "#EAECEBFF"
+            ]
+        },
+        {
+            "fila_color_code": "13502",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "绿色",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#4CE4A0FF"
+            ]
+        },
+        {
+            "fila_color_code": "13300",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Kupfer",
+                "sv": "Koppar",
+                "pt": "Cobre",
+                "ko": "코퍼",
+                "ja": "カッパー",
+                "en": "Copper",
+                "it": "Rame",
+                "fr": "Cuivre",
+                "hu": "Réz",
+                "zh": "铜色",
+                "nl": "Koperkleurig",
+                "es": "Cobre"
+            },
+            "fila_color": [
+                "#5E4B3CFF"
+            ]
+        },
+        {
+            "fila_color_code": "13202",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Pink",
+                "sv": "Rosa",
+                "pt": "Rosa",
+                "ko": "핑크",
+                "ja": "ピンク",
+                "en": "Pink",
+                "it": "Rosa",
+                "fr": "Rose",
+                "hu": "Rózsaszín",
+                "zh": "粉色",
+                "nl": "Roze",
+                "es": "Rosa"
+            },
+            "fila_color": [
+                "#EEB1C1FF"
+            ]
+        },
+        {
+            "fila_color_code": "13701",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Lila",
+                "sv": "Lila",
+                "pt": "Roxo",
+                "ko": "퍼플",
+                "ja": "パープル",
+                "en": "Purple",
+                "it": "Viola",
+                "fr": "Violet",
+                "hu": "Lila",
+                "zh": "紫色",
+                "nl": "Paars",
+                "es": "Púrpura"
+            },
+            "fila_color": [
+                "#854CE4FF"
+            ]
+        },
+        {
+            "fila_color_code": "13901",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Goldenes Rosa",
+                "sv": "Gyllene ros",
+                "pt": "Rosa Dourada",
+                "ko": "길디드 로즈",
+                "ja": "ギルディッド ローズ",
+                "en": "Gilded Rose",
+                "it": "Rosa con sfumature dorate",
+                "fr": "Rose doré",
+                "hu": "Aranyozott rózsa",
+                "zh": "金粉双色",
+                "nl": "Vergulde roos",
+                "es": "Rosa dorado"
+            },
+            "fila_color": [
+                "#FF9425FF",
+                "#C16784FF"
+            ]
+        },
+        {
+            "fila_color_code": "13902",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Mitternachtsglanz",
+                "sv": "Midnattsflamma",
+                "pt": "Midnight Blaze",
+                "ko": "미드나이트 블레이즈",
+                "ja": "ミッドナイト ブレイズ",
+                "en": "Midnight Blaze",
+                "it": "Midnight Blaze",
+                "fr": "Feu de minuit",
+                "hu": "Éjféli ragyogás",
+                "zh": "蓝红双色",
+                "nl": "Middernachtblauw",
+                "es": "Resplandor de medianoche"
+            },
+            "fila_color": [
+                "#0047BBFF",
+                "#7D1B49FF"
+            ]
+        },
+        {
+            "fila_color_code": "13903",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Neon City",
+                "sv": "Stadsljus",
+                "pt": "Cidade Neon",
+                "ko": "네온 시티",
+                "ja": "ネオン シティ",
+                "en": "Neon City",
+                "it": "Neon City",
+                "fr": "Ville de Néon",
+                "hu": "Neonfény",
+                "zh": "蓝粉双色",
+                "nl": "Neonstad",
+                "es": "Ciudad de neón"
+            },
+            "fila_color": [
+                "#BB22A3FF",
+                "#0047BBFF"
+            ]
+        },
+        {
+            "fila_color_code": "13904",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Hawaii-Blau",
+                "sv": "Blå Hawaii",
+                "pt": "Blue Hawaii",
+                "ko": "블루 하와이",
+                "ja": "ブルー ハワイ",
+                "en": "Blue Hawaii",
+                "it": "Blue Hawaii",
+                "fr": "Hawaï bleu",
+                "hu": "Kék Hawaii",
+                "zh": "蓝绿双色",
+                "nl": "Blauw Hawaï",
+                "es": "Azul Hawái"
+            },
+            "fila_color": [
+                "#70C884FF",
+                "#418FDEFF"
+            ]
+        },
+        {
+            "fila_color_code": "13905",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Dunkler Samt (Schwarz-Rot)",
+                "sv": "Sammetsglans (svart-röd)",
+                "pt": "Velvet Eclipse (Preto-Vermelho)",
+                "ko": "벨벳 이클립스(블랙-레드)",
+                "ja": "ベルベット エクリプス (ブラック レッド)",
+                "en": "Velvet Eclipse (Black-Red)",
+                "it": "Velvet Eclipse (nero/rosso)",
+                "fr": "Éclipse de velours (Noir-Rouge)",
+                "hu": "Bársony naplemente (fekete-piros)",
+                "zh": "灰烬红",
+                "nl": "Fluwelen zonsverduistering (zwart-rood)",
+                "es": "Eclipse de terciopelo (negro-rojo)"
+            },
+            "fila_color": [
+                "#000000FF",
+                "#A34342FF"
+            ]
+        },
+        {
+            "fila_color_code": "13105",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "13401",
+            "fila_id": "GFA05",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "Gold",
+                "sv": "Guld",
+                "pt": "Dourado",
+                "ko": "골드",
+                "ja": "ゴールド",
+                "en": "Gold",
+                "it": "Oro",
+                "fr": "Doré",
+                "hu": "Arany",
+                "zh": "金色",
+                "nl": "Goud",
+                "es": "Dorado"
+            },
+            "fila_color": [
+                "#E5B03DFF"
+            ]
+        },
+        {
+            "fila_color_code": "13603",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Babyblau",
+                "sv": "Babyblå",
+                "pt": "Azul-bebê",
+                "ko": "베이비 블루",
+                "ja": "ベイビー ブルー",
+                "en": "Baby Blue",
+                "it": "Blu-turchese chiaro",
+                "fr": "Bleu layette",
+                "hu": "Babakék",
+                "zh": "天空蓝",
+                "nl": "Babyblauw",
+                "es": "Azul bebé"
+            },
+            "fila_color": [
+                "#A8C6EEFF"
+            ]
+        },
+        {
+            "fila_color_code": "13604",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "丝绸蓝",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#008BDAFF"
+            ]
+        },
+        {
+            "fila_color_code": "13108",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Titangrau",
+                "sv": "Titangrå",
+                "pt": "Titan Gray",
+                "ko": "타이탄 그레이",
+                "ja": "チタン グレー",
+                "en": "Titan Gray",
+                "it": "Grigio titanio",
+                "fr": "Gris titane",
+                "hu": "Titánszürke",
+                "zh": "钛灰色",
+                "nl": "Titaangrijs",
+                "es": "Gris titán"
+            },
+            "fila_color": [
+                "#5F6367FF"
+            ]
+        },
+        {
+            "fila_color_code": "13109",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Silber",
+                "sv": "Silver",
+                "pt": "Prateado",
+                "ko": "실버",
+                "ja": "シルバー",
+                "en": "Silver",
+                "it": "Argento",
+                "fr": "Argenté",
+                "hu": "Ezüst",
+                "zh": "丝绸银",
+                "nl": "Zilver",
+                "es": "Plateado"
+            },
+            "fila_color": [
+                "#C8C8C8FF"
+            ]
+        },
+        {
+            "fila_color_code": "13506",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Candy-Grün",
+                "sv": "Godisgrön",
+                "pt": "Candy Green",
+                "ko": "캔디 그린",
+                "ja": "キャンディ グリーン",
+                "en": "Candy Green",
+                "it": "Verde caramella",
+                "fr": "Vert bonbon",
+                "hu": "Cukorkazöld",
+                "zh": "糖果绿",
+                "nl": "Snoepgroen",
+                "es": "Verde caramelo"
+            },
+            "fila_color": [
+                "#018814FF"
+            ]
+        },
+        {
+            "fila_color_code": "13507",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Minze",
+                "sv": "Mint",
+                "pt": "Menta",
+                "ko": "민트",
+                "ja": "ミント",
+                "en": "Mint",
+                "it": "Menta",
+                "fr": "Menthe",
+                "hu": "Menta",
+                "zh": "薄荷绿",
+                "nl": "Munt",
+                "es": "Menta"
+            },
+            "fila_color": [
+                "#96DCB9FF"
+            ]
+        },
+        {
+            "fila_color_code": "13702",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Lila",
+                "sv": "Lila",
+                "pt": "Roxo",
+                "ko": "퍼플",
+                "ja": "パープル",
+                "en": "Purple",
+                "it": "Viola",
+                "fr": "Violet",
+                "hu": "Lila",
+                "zh": "丝绸紫",
+                "nl": "Paars",
+                "es": "Púrpura"
+            },
+            "fila_color": [
+                "#8671CBFF"
+            ]
+        },
+        {
+            "fila_color_code": "13205",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Candy-Rot",
+                "sv": "Godisröd",
+                "pt": "Candy Red",
+                "ko": "캔디 레드",
+                "ja": "キャンディ レッド",
+                "en": "Candy Red",
+                "it": "Rosso caramella",
+                "fr": "Rouge bonbon",
+                "hu": "Cukorkapiros",
+                "zh": "糖果红",
+                "nl": "Snoeprood",
+                "es": "Rojo caramelo"
+            },
+            "fila_color": [
+                "#D02727FF"
+            ]
+        },
+        {
+            "fila_color_code": "13206",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Gold-Rosa",
+                "sv": "Rödguld",
+                "pt": "Ouro Rosa",
+                "ko": "로즈 골드",
+                "ja": "ローズ ゴールド",
+                "en": "Rose Gold",
+                "it": "Oro rosa",
+                "fr": "Doré rose",
+                "hu": "Rózsaarany",
+                "zh": "烟粉色",
+                "nl": "Roségoud",
+                "es": "Oro rosa"
+            },
+            "fila_color": [
+                "#BA9594FF"
+            ]
+        },
+        {
+            "fila_color_code": "13207",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Pink",
+                "sv": "Rosa",
+                "pt": "Rosa",
+                "ko": "핑크",
+                "ja": "ピンク",
+                "en": "Pink",
+                "it": "Rosa",
+                "fr": "Rose",
+                "hu": "Rózsaszín",
+                "zh": "丝绸粉",
+                "nl": "Roze",
+                "es": "Rosa"
+            },
+            "fila_color": [
+                "#F7ADA6FF"
+            ]
+        },
+        {
+            "fila_color_code": "13110",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "丝绸白",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "13404",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Champagner",
+                "sv": "Champagne",
+                "pt": "Champagne",
+                "ko": "샴페인",
+                "ja": "シャンパン",
+                "en": "Champagne",
+                "it": "Champagne",
+                "fr": "Champagne",
+                "hu": "Pezsgő",
+                "zh": "香槟色",
+                "nl": "Champagne",
+                "es": "Champán"
+            },
+            "fila_color": [
+                "#F3CFB2FF"
+            ]
+        },
+        {
+            "fila_color_code": "13405",
+            "fila_id": "GFA06",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Silk+",
+            "fila_color_name": {
+                "de": "Gold",
+                "sv": "Guld",
+                "pt": "Dourado",
+                "ko": "골드",
+                "ja": "ゴールド",
+                "en": "Gold",
+                "it": "Oro",
+                "fr": "Doré",
+                "hu": "Arany",
+                "zh": "丝绸金",
+                "nl": "Goud",
+                "es": "Dorado"
+            },
+            "fila_color": [
+                "#F4A925FF"
+            ]
+        },
+        {
+            "fila_color_code": "13103",
+            "fila_id": "GFA07",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Marble",
+            "fila_color_name": {
+                "de": "Weißer Marmor",
+                "sv": "Vit marmor",
+                "pt": "Mármore Branco",
+                "ko": "화이트 마블",
+                "ja": "ホワイト マーブル",
+                "en": "White Marble",
+                "it": "Marmo bianco",
+                "fr": "Marbre blanc",
+                "hu": "Fehér márvány",
+                "zh": "大理石",
+                "nl": "Wit marmer",
+                "es": "Mármol blanco"
+            },
+            "fila_color": [
+                "#F7F3F0FF"
+            ]
+        },
+        {
+            "fila_color_code": "13201",
+            "fila_id": "GFA07",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Marble",
+            "fila_color_name": {
+                "de": "Granitrot",
+                "sv": "Röd granit",
+                "pt": "Granito Vermelho",
+                "ko": "레드 그래나이트",
+                "ja": "レッド グラナイト",
+                "en": "Red Granite",
+                "it": "Rosso granito",
+                "fr": "Granit rouge",
+                "hu": "Vörös gránit",
+                "zh": "砖红",
+                "nl": "Rood graniet",
+                "es": "Granate rojo"
+            },
+            "fila_color": [
+                "#AD4E38FF"
+            ]
+        },
+        {
+            "fila_color_code": "13700",
+            "fila_id": "GFA08",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Sparkle",
+            "fila_color_name": {
+                "de": "Glitzerndes Königslila",
+                "sv": "Kungslila glans",
+                "pt": "Royal Purple Sparkle",
+                "ko": "로얄 퍼플 스파클",
+                "ja": "ロイヤル パープル スパークル",
+                "en": "Royal Purple Sparkle",
+                "it": "Viola reale con brillantini",
+                "fr": "Violet royal scintillant",
+                "hu": "Csillámló királyi lila",
+                "zh": "深蓝",
+                "nl": "Sprankelend koningspaars",
+                "es": "Púrpura real brillante"
+            },
+            "fila_color": [
+                "#483D8BFF"
+            ]
+        },
+        {
+            "fila_color_code": "13102",
+            "fila_id": "GFA08",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Sparkle",
+            "fila_color_name": {
+                "de": "Glitzerndes Schiefergrau",
+                "sv": "Granitgrå glans",
+                "pt": "Slate Gray Sparkle",
+                "ko": "슬레이트 그레이 스파클",
+                "ja": "スレート グレース パークル",
+                "en": "Slate Gray Sparkle",
+                "it": "Grigio ardesia con brillantini",
+                "fr": "Gris ardoise scintillant",
+                "hu": "Csillámló palaszürke",
+                "zh": "灰色",
+                "nl": "Sprankelend leigrijs",
+                "es": "Gris pizarra brillante"
+            },
+            "fila_color": [
+                "#8E9089FF"
+            ]
+        },
+        {
+            "fila_color_code": "13501",
+            "fila_id": "GFA08",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Sparkle",
+            "fila_color_name": {
+                "de": "Glitzerndes Alpengrün",
+                "sv": "Alpingrön glans",
+                "pt": "Alpine Green Sparkle",
+                "ko": "알파인 그린 스파클",
+                "ja": "アルパイン グリーン スパークル",
+                "en": "Alpine Green Sparkle",
+                "it": "Verde alpino con brillantini",
+                "fr": "Vert alpin scintillant",
+                "hu": "Alpesi csillogó zöld",
+                "zh": "绿色",
+                "nl": "Sprankelend alpengroen",
+                "es": "Verde alpino brillante"
+            },
+            "fila_color": [
+                "#3F5443FF"
+            ]
+        },
+        {
+            "fila_color_code": "13101",
+            "fila_id": "GFA08",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Sparkle",
+            "fila_color_name": {
+                "de": "Glitzerndes Onyx-Schwarz",
+                "sv": "Onyxsvart glans",
+                "pt": "Onyx Black Sparkle",
+                "ko": "오닉스 블랙 스파클",
+                "ja": "オニキス ブラック スパークル",
+                "en": "Onyx Black Sparkle",
+                "it": "Nero onice con brillantini",
+                "fr": "Onyx noir scintillant",
+                "hu": "Csillámló ónixfekete",
+                "zh": "黑色",
+                "nl": "Sprankelend onyxzwart",
+                "es": "Negro ónix brillante"
+            },
+            "fila_color": [
+                "#2D2B28FF"
+            ]
+        },
+        {
+            "fila_color_code": "13200",
+            "fila_id": "GFA08",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Sparkle",
+            "fila_color_name": {
+                "de": "Glitzerndes Karminrot",
+                "sv": "Mörkröd glans",
+                "pt": "Crimson Red Sparkle",
+                "ko": "크림슨 레드 스파클",
+                "ja": "クリムゾン レッド スパークル",
+                "en": "Crimson Red Sparkle",
+                "it": "Rosso cremisi con brillantini",
+                "fr": "Pourpre scintillant",
+                "hu": "Csillámló bíborvörös",
+                "zh": "红色",
+                "nl": "Sprankelend karmozijnrood",
+                "es": "Rojo carmesí brillante"
+            },
+            "fila_color": [
+                "#792B36FF"
+            ]
+        },
+        {
+            "fila_color_code": "13402",
+            "fila_id": "GFA08",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Sparkle",
+            "fila_color_name": {
+                "de": "Klassisches Glitzer-Gold",
+                "sv": "Klassisk guld glans",
+                "pt": "Classic Gold Sparkle",
+                "ko": "클래식 골드 스파클",
+                "ja": "クラシック ゴールド スパークル",
+                "en": "Classic Gold Sparkle",
+                "it": "Oro con brillantini",
+                "fr": "Doré classique scintillant",
+                "hu": "Klasszikus csillogó arany",
+                "zh": "金色",
+                "nl": "Sprankelend klassiek goud",
+                "es": "Dorado clásico brillante"
+            },
+            "fila_color": [
+                "#CEA629FF"
+            ]
+        },
+        {
+            "fila_color_code": "12300",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Orange",
+                "sv": "Orange",
+                "pt": "Laranja",
+                "ko": "오렌지",
+                "ja": "オレンジ",
+                "en": "Orange",
+                "it": "Arancione",
+                "fr": "Orange",
+                "hu": "Narancssárga",
+                "zh": "橙色",
+                "nl": "Oranje",
+                "es": "Naranja"
+            },
+            "fila_color": [
+                "#FF7F41FF"
+            ]
+        },
+        {
+            "fila_color_code": "12600",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Hellblau",
+                "sv": "Ljusblå",
+                "pt": "Azul-claro",
+                "ko": "라이트 블루",
+                "ja": "ライト ブルー",
+                "en": "Light Blue",
+                "it": "Azzurro chiaro",
+                "fr": "Bleu clair",
+                "hu": "Világoskék",
+                "zh": "浅蓝",
+                "nl": "Lichtblauw",
+                "es": "Azul claro"
+            },
+            "fila_color": [
+                "#0085ADFF"
+            ]
+        },
+        {
+            "fila_color_code": "12700",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Lavendelblau",
+                "sv": "Lavendelblå",
+                "pt": "Azul-lavanda",
+                "ko": "라벤더 블루",
+                "ja": "ラベンダー ブルー",
+                "en": "Lavender Blue",
+                "it": "Blu lavanda",
+                "fr": "Bleu lavande",
+                "hu": "Levendulakék",
+                "zh": "薰衣草紫",
+                "nl": "Lavendelblauw",
+                "es": "Azul lavanda"
+            },
+            "fila_color": [
+                "#6667ABFF"
+            ]
+        },
+        {
+            "fila_color_code": "12102",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#515A6CFF"
+            ]
+        },
+        {
+            "fila_color_code": "12103",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Silber",
+                "sv": "Silver",
+                "pt": "Prateado",
+                "ko": "실버",
+                "ja": "シルバー",
+                "en": "Silver",
+                "it": "Argento",
+                "fr": "Argenté",
+                "hu": "Ezüst",
+                "zh": "银色",
+                "nl": "Zilver",
+                "es": "Plateado"
+            },
+            "fila_color": [
+                "#898D8DFF"
+            ]
+        },
+        {
+            "fila_color_code": "12500",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Tannengrün",
+                "sv": "Pinjegrön",
+                "pt": "Pinho Verde",
+                "ko": "파인 그린",
+                "ja": "パイン グリーン",
+                "en": "Pine Green",
+                "it": "Verde pino",
+                "fr": "Vert pin",
+                "hu": "Fenyőzöld",
+                "zh": "松绿",
+                "nl": "Dennengroen",
+                "es": "Verde pino"
+            },
+            "fila_color": [
+                "#00482BFF"
+            ]
+        },
+        {
+            "fila_color_code": "12101",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#25282AFF"
+            ]
+        },
+        {
+            "fila_color_code": "12200",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Zinnoberrot",
+                "sv": "Vermilionröd",
+                "pt": "Vermelho Vermilion",
+                "ko": "버밀리언 레드",
+                "ja": "バーミリオン レッド",
+                "en": "Vermilion Red",
+                "it": "Rosso vermiglio",
+                "fr": "Rouge vermillon",
+                "hu": "Cinóbervörös",
+                "zh": "朱砂红",
+                "nl": "Vermiljoenrood",
+                "es": "Rojo bermellón"
+            },
+            "fila_color": [
+                "#DD3C22FF"
+            ]
+        },
+        {
+            "fila_color_code": "12100",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#F9F7F4FF"
+            ]
+        },
+        {
+            "fila_color_code": "12400",
+            "fila_id": "GFA09",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#FEDB00FF"
+            ]
+        },
+        {
+            "fila_color_code": "14104",
+            "fila_id": "GFA11",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Aero",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#CDCECAFF"
+            ]
+        },
+        {
+            "fila_color_code": "14103",
+            "fila_id": "GFA11",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Aero",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "14102",
+            "fila_id": "GFA11",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Aero",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "15300",
+            "fila_id": "GFA12",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Glow",
+            "fila_color_name": {
+                "de": "Leuchtend-Orange",
+                "sv": "Orange glöd",
+                "pt": "Brilho Laranja",
+                "ko": "글로우 오렌지",
+                "ja": "グロー オレンジ",
+                "en": "Glow Orange",
+                "it": "Arancione fosforescente",
+                "fr": "Orange éclatant",
+                "hu": "Ragyogó narancssárga",
+                "zh": "夜光橙",
+                "nl": "Oranje gloed",
+                "es": "Naranja brillante"
+            },
+            "fila_color": [
+                "#FF9D5BFF"
+            ]
+        },
+        {
+            "fila_color_code": "15600",
+            "fila_id": "GFA12",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Glow",
+            "fila_color_name": {
+                "de": "Leuchtend-Blau",
+                "sv": "Blå glöd",
+                "pt": "Brilho Azul",
+                "ko": "글로우 블루",
+                "ja": "グロー ブルー",
+                "en": "Glow Blue",
+                "it": "Blu fosforescente",
+                "fr": "Bleu éclatant",
+                "hu": "Ragyogó kék",
+                "zh": "夜光蓝",
+                "nl": "Blauwe gloed",
+                "es": "Azul brillante"
+            },
+            "fila_color": [
+                "#7AC0E9FF"
+            ]
+        },
+        {
+            "fila_color_code": "15500",
+            "fila_id": "GFA12",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Glow",
+            "fila_color_name": {
+                "de": "Leuchtend-Grün",
+                "sv": "Grön glöd",
+                "pt": "Brilho Verde",
+                "ko": "글로우 그린",
+                "ja": "グロー グリーン",
+                "en": "Glow Green",
+                "it": "Verde fosforescente",
+                "fr": "Vert éclatant",
+                "hu": "Ragyogó zöld",
+                "zh": "夜光绿",
+                "nl": "Groene gloed",
+                "es": "Verde brillante"
+            },
+            "fila_color": [
+                "#A1FFACFF"
+            ]
+        },
+        {
+            "fila_color_code": "15200",
+            "fila_id": "GFA12",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Glow",
+            "fila_color_name": {
+                "de": "Leuchtend-Pink",
+                "sv": "Rosa glöd",
+                "pt": "Rosa Brilhante",
+                "ko": "글로우 핑크",
+                "ja": "グロー ピンク",
+                "en": "Glow Pink",
+                "it": "Rosa fosforescente",
+                "fr": "Rose éclatant",
+                "hu": "Ragyogó rózsaszín",
+                "zh": "夜光粉",
+                "nl": "Roze gloed",
+                "es": "Rosa brillante"
+            },
+            "fila_color": [
+                "#F17B8FFF"
+            ]
+        },
+        {
+            "fila_color_code": "15400",
+            "fila_id": "GFA12",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Glow",
+            "fila_color_name": {
+                "de": "Leuchtend-Gelb",
+                "sv": "Gul glöd",
+                "pt": "Amarelo Brilhante",
+                "ko": "글로우 옐로우",
+                "ja": "グロー イエロー",
+                "en": "Glow Yellow",
+                "it": "Giallo fosforescente",
+                "fr": "Jaune éclatant",
+                "hu": "Ragyogó sárga",
+                "zh": "夜光黄",
+                "nl": "Gele gloed",
+                "es": "Amarillo brillante"
+            },
+            "fila_color": [
+                "#F8FF80FF"
+            ]
+        },
+        {
+            "fila_color_code": "15100",
+            "fila_id": "GFA13",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Dynamic",
+            "fila_color_name": {
+                "de": "UV-Farbwechsel – Weiß nach Koralle",
+                "sv": "UV-toning - vit till korall",
+                "pt": "Mudança de cor UV — Branco para coral",
+                "ko": "UV 컬러 변경 - 화이트에서 코랄로",
+                "ja": "UV カラー チェンジ - ホワイトからコーラル",
+                "en": "UV Color Changing - White to Coral",
+                "it": "Cambia colore con l'esposizione ai raggi UV - Da bianco a corallo",
+                "fr": "Changement de couleur UV - Blanc à corail",
+                "hu": "UV-színváltó – fehérről korallra",
+                "zh": "光变-白变粉",
+                "nl": "UV-kleurverandering: wit naar koraal",
+                "es": "De blanco a coral (Cambia con los rayos UV)"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "13602",
+            "fila_id": "GFA15",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Galaxy",
+            "fila_color_name": {
+                "de": "Lila",
+                "sv": "Lila",
+                "pt": "Roxo",
+                "ko": "퍼플",
+                "ja": "パープル",
+                "en": "Purple",
+                "it": "Viola",
+                "fr": "Violet",
+                "hu": "Lila",
+                "zh": "星河紫",
+                "nl": "Paars",
+                "es": "Púrpura"
+            },
+            "fila_color": [
+                "#594177FF"
+            ]
+        },
+        {
+            "fila_color_code": "13503",
+            "fila_id": "GFA15",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Galaxy",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "星河绿",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#3B665EFF"
+            ]
+        },
+        {
+            "fila_color_code": "13504",
+            "fila_id": "GFA15",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Galaxy",
+            "fila_color_name": {
+                "de": "Nebel",
+                "sv": "Nebulosor",
+                "pt": "Nebulae",
+                "ko": "네뷸라",
+                "ja": "ネビュリー",
+                "en": "Nebulae",
+                "it": "Nebula",
+                "fr": "Nébuleuse",
+                "hu": "Űrbéli ködök",
+                "zh": "星云色",
+                "nl": "Nevelig",
+                "es": "Nebulosa"
+            },
+            "fila_color": [
+                "#424379FF"
+            ]
+        },
+        {
+            "fila_color_code": "13203",
+            "fila_id": "GFA15",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Galaxy",
+            "fila_color_name": {
+                "de": "Braun",
+                "sv": "Brun",
+                "pt": "Marrom",
+                "ko": "브라운",
+                "ja": "ブラウン",
+                "en": "Brown",
+                "it": "Marrone",
+                "fr": "Marron",
+                "hu": "Barna",
+                "zh": "星河棕",
+                "nl": "Bruin",
+                "es": "Marrón"
+            },
+            "fila_color": [
+                "#684A43FF"
+            ]
+        },
+        {
+            "fila_color_code": "13505",
+            "fila_id": "GFA16",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Wood",
+            "fila_color_name": {
+                "de": "Klassische Birke",
+                "sv": "Klassisk björk",
+                "pt": "Classic Birch",
+                "ko": "클래식 버치",
+                "ja": "クラシック バーチ",
+                "en": "Classic Birch",
+                "it": "Betulla",
+                "fr": "Bouleau classique",
+                "hu": "Klasszikus nyírfa",
+                "zh": "经典桦木",
+                "nl": "Klassieke berk",
+                "es": "Abedul clásico"
+            },
+            "fila_color": [
+                "#918669FF"
+            ]
+        },
+        {
+            "fila_color_code": "13107",
+            "fila_id": "GFA16",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Wood",
+            "fila_color_name": {
+                "de": "Schwarze Walnuss",
+                "sv": "Svart valnöt",
+                "pt": "Noz preta",
+                "ko": "블랙 월넛",
+                "ja": "ブラック ウォールナット",
+                "en": "Black Walnut",
+                "it": "Noce nero",
+                "fr": "Noyer noir",
+                "hu": "Fekete dió",
+                "zh": "黑胡桃",
+                "nl": "Walnootzwart",
+                "es": "Nogal negro"
+            },
+            "fila_color": [
+                "#4F3F24FF"
+            ]
+        },
+        {
+            "fila_color_code": "13801",
+            "fila_id": "GFA16",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Wood",
+            "fila_color_name": {
+                "de": "Lehmbraun",
+                "sv": "Lerbrun",
+                "pt": "Clay Brown",
+                "ko": "클레이 브라운",
+                "ja": "クレイ ブラウン",
+                "en": "Clay Brown",
+                "it": "Marrone argilla",
+                "fr": "Marron argile",
+                "hu": "Agyagbarna",
+                "zh": "陶土褐",
+                "nl": "Modderbruin",
+                "es": "Marrón arcilla"
+            },
+            "fila_color": [
+                "#995F11FF"
+            ]
+        },
+        {
+            "fila_color_code": "13204",
+            "fila_id": "GFA16",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Wood",
+            "fila_color_name": {
+                "de": "Rosenholz",
+                "sv": "Rosenträ",
+                "pt": "Jacarandá",
+                "ko": "로즈우드",
+                "ja": "ローズウッド",
+                "en": "Rosewood",
+                "it": "Palissandro",
+                "fr": "Palissandre",
+                "hu": "Rózsafa",
+                "zh": "红木",
+                "nl": "Rozenhout",
+                "es": "Palo de rosa"
+            },
+            "fila_color": [
+                "#4C241CFF"
+            ]
+        },
+        {
+            "fila_color_code": "13106",
+            "fila_id": "GFA16",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Wood",
+            "fila_color_name": {
+                "de": "Weiße Eiche",
+                "sv": "Vit ek",
+                "pt": "Carvalho Branco",
+                "ko": "화이트 오크",
+                "ja": "ホワイト オーク",
+                "en": "White Oak",
+                "it": "Rovere bianco",
+                "fr": "Chêne blanc",
+                "hu": "Fehér tölgy",
+                "zh": "白橡木",
+                "nl": "Wit eiken",
+                "es": "Roble blanco"
+            },
+            "fila_color": [
+                "#D6CCA3FF"
+            ]
+        },
+        {
+            "fila_color_code": "13403",
+            "fila_id": "GFA16",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Wood",
+            "fila_color_name": {
+                "de": "Ockergelb",
+                "sv": "Ockragul",
+                "pt": "Amarelo-ocre",
+                "ko": "오커 옐로우",
+                "ja": "オーカー イエロー",
+                "en": "Ochre Yellow",
+                "it": "Giallo ocra",
+                "fr": "Jaune ocre",
+                "hu": "Okkersárga",
+                "zh": "赭石黄",
+                "nl": "Okergeel",
+                "es": "Amarillo ocre"
+            },
+            "fila_color": [
+                "#C98935FF"
+            ]
+        },
+        {
+            "fila_color_code": "14601",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Königsblau",
+                "sv": "Kungsblå",
+                "pt": "Azul Royal",
+                "ko": "로얄 블루",
+                "ja": "ロイヤル ブルー",
+                "en": "Royal Blue",
+                "it": "Blu royal",
+                "fr": "Bleu royal",
+                "hu": "Királykék",
+                "zh": "皇家蓝",
+                "nl": "Koningsblauw",
+                "es": "Azul real"
+            },
+            "fila_color": [
+                "#2842ADFF"
+            ]
+        },
+        {
+            "fila_color_code": "14600",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Jeansblau",
+                "sv": "Jeansblå",
+                "pt": "Jeans Azul",
+                "ko": "진 블루",
+                "ja": "ジーンズ ブルー",
+                "en": "Jeans Blue",
+                "it": "Blu jeans",
+                "fr": "Jean bleu",
+                "hu": "Farmerkék",
+                "zh": "牛仔蓝",
+                "nl": "Jeansblauw",
+                "es": "Azul vaquero"
+            },
+            "fila_color": [
+                "#6e88bcFF"
+            ]
+        },
+        {
+            "fila_color_code": "14101",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Lava-Grau",
+                "sv": "Lavagrå",
+                "pt": "Lava Cinza",
+                "ko": "라바 그레이",
+                "ja": "ラバ グレー",
+                "en": "Lava Gray",
+                "it": "Grigio lava",
+                "fr": "Gris lave",
+                "hu": "Lávaszürke",
+                "zh": "熔岩灰",
+                "nl": "Lavagrijs",
+                "es": "Gris lava"
+            },
+            "fila_color": [
+                "#4d5054FF"
+            ]
+        },
+        {
+            "fila_color_code": "14500",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Matcha-Grün",
+                "sv": "Matchagrön",
+                "pt": "Matcha Green",
+                "ko": "마차 그린",
+                "ja": "抹茶グリーン",
+                "en": "Matcha Green",
+                "it": "Verde matcha",
+                "fr": "Vert matcha",
+                "hu": "Matchazöld",
+                "zh": "抹茶绿",
+                "nl": "Matchagroen",
+                "es": "Verde matcha"
+            },
+            "fila_color": [
+                "#5c9748FF"
+            ]
+        },
+        {
+            "fila_color_code": "14100",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "14700",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Iris-Violett",
+                "sv": "Irislila",
+                "pt": "Íris Roxa",
+                "ko": "아이리스 퍼플",
+                "ja": "アイリス パープル",
+                "en": "Iris Purple",
+                "it": "Viola iris",
+                "fr": "Violet iris",
+                "hu": "Íriszlila",
+                "zh": "鸢尾花紫",
+                "nl": "Irispaars",
+                "es": "Púrpura iris"
+            },
+            "fila_color": [
+                "#69398EFF"
+            ]
+        },
+        {
+            "fila_color_code": "14200",
+            "fila_id": "GFA50",
+            "fila_color_type": "单色",
+            "fila_type": "PLA-CF",
+            "fila_color_name": {
+                "de": "Burgunderrot",
+                "sv": "Vinröd",
+                "pt": "Burgundy Red",
+                "ko": "버건디 레드",
+                "ja": "バーガンディ レッド",
+                "en": "Burgundy Red",
+                "it": "Rosso borgogna",
+                "fr": "Rouge bordeaux",
+                "hu": "Bordó-vörös",
+                "zh": "勃艮第红",
+                "nl": "Wijnrood",
+                "es": "Rojo burdeos"
+            },
+            "fila_color": [
+                "#951e23FF"
+            ]
+        },
+        {
+            "fila_color_code": "40300",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Orange",
+                "sv": "Orange",
+                "pt": "Laranja",
+                "ko": "오렌지",
+                "ja": "オレンジ",
+                "en": "Orange",
+                "it": "Arancione",
+                "fr": "Orange",
+                "hu": "Narancssárga",
+                "zh": "橙色",
+                "nl": "Oranje",
+                "es": "Naranja"
+            },
+            "fila_color": [
+                "#FF6A13FF"
+            ]
+        },
+        {
+            "fila_color_code": "40600",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#0A2CA5FF"
+            ]
+        },
+        {
+            "fila_color_code": "40601",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Azurblau",
+                "sv": "Azurblå",
+                "pt": "Azure",
+                "ko": "애저",
+                "ja": "アズール",
+                "en": "Azure",
+                "it": "Azzurro",
+                "fr": "Bleu azur",
+                "hu": "Azúr",
+                "zh": "天蓝色",
+                "nl": "Azuurblauw",
+                "es": "Azul celeste"
+            },
+            "fila_color": [
+                "#489FDFFF"
+            ]
+        },
+        {
+            "fila_color_code": "40602",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Marineblau",
+                "sv": "Marinblå",
+                "pt": "Azul-marinho",
+                "ko": "네이비 블루",
+                "ja": "ネイビー ブルー",
+                "en": "Navy Blue",
+                "it": "Blu navy",
+                "fr": "Bleu marine",
+                "hu": "Tengerészkék",
+                "zh": "藏青色",
+                "nl": "Marineblauw",
+                "es": "Azul marino oscuro"
+            },
+            "fila_color": [
+                "#0C2340FF"
+            ]
+        },
+        {
+            "fila_color_code": "40501",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Minze",
+                "sv": "Mint",
+                "pt": "Menta",
+                "ko": "민트",
+                "ja": "ミント",
+                "en": "Mint",
+                "it": "Menta",
+                "fr": "Menthe",
+                "hu": "Menta",
+                "zh": "青色",
+                "nl": "Munt",
+                "es": "Menta"
+            },
+            "fila_color": [
+                "#7AE1BFFF"
+            ]
+        },
+        {
+            "fila_color_code": "40102",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Silber",
+                "sv": "Silver",
+                "pt": "Prateado",
+                "ko": "실버",
+                "ja": "シルバー",
+                "en": "Silver",
+                "it": "Argento",
+                "fr": "Argenté",
+                "hu": "Ezüst",
+                "zh": "银色",
+                "nl": "Zilver",
+                "es": "Plateado"
+            },
+            "fila_color": [
+                "#87909AFF"
+            ]
+        },
+        {
+            "fila_color_code": "40500",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Bambusgrün",
+                "sv": "Bambugrön",
+                "pt": "Verde-bambu",
+                "ko": "뱀부 그린",
+                "ja": "バンブー グリーン",
+                "en": "Bambu Green",
+                "it": "Verde bambù",
+                "fr": "Vert bambou",
+                "hu": "Bambu-zöld",
+                "zh": "拓竹绿",
+                "nl": "Bamboegroen",
+                "es": "Verde bambú"
+            },
+            "fila_color": [
+                "#00AE42FF"
+            ]
+        },
+        {
+            "fila_color_code": "40502",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Olive",
+                "sv": "Oliv",
+                "pt": "Olive",
+                "ko": "올리브",
+                "ja": "オリーブ",
+                "en": "Olive",
+                "it": "Oliva",
+                "fr": "Olive",
+                "hu": "Olivazöld",
+                "zh": "橄榄绿",
+                "nl": "Olijf",
+                "es": "Oliva"
+            },
+            "fila_color": [
+                "#789D4AFF"
+            ]
+        },
+        {
+            "fila_color_code": "40101",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "40701",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Lavendel",
+                "sv": "Lavendel",
+                "pt": "Lavanda",
+                "ko": "라벤더",
+                "ja": "ラベンダー",
+                "en": "Lavender",
+                "it": "Lavanda",
+                "fr": "Lavande",
+                "hu": "Levendula",
+                "zh": "薰衣草紫",
+                "nl": "Lavendel",
+                "es": "Lavanda"
+            },
+            "fila_color": [
+                "#7248BDFF"
+            ]
+        },
+        {
+            "fila_color_code": "40700",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Lila",
+                "sv": "Lila",
+                "pt": "Roxo",
+                "ko": "퍼플",
+                "ja": "パープル",
+                "en": "Purple",
+                "it": "Viola",
+                "fr": "Violet",
+                "hu": "Lila",
+                "zh": "紫色",
+                "nl": "Paars",
+                "es": "Púrpura"
+            },
+            "fila_color": [
+                "#AF1685FF"
+            ]
+        },
+        {
+            "fila_color_code": "40200",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#D32941FF"
+            ]
+        },
+        {
+            "fila_color_code": "40100",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "40400",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#FCE900FF"
+            ]
+        },
+        {
+            "fila_color_code": "40402",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Mandarinengelb",
+                "sv": "Mandaringul",
+                "pt": "Amarelo Tangerina",
+                "ko": "탠저린 옐로우",
+                "ja": "タンジェリン イエロー",
+                "en": "Tangerine Yellow",
+                "it": "Giallo tangerine",
+                "fr": "Jaune mandarine",
+                "hu": "Tangerin",
+                "zh": "橘黄",
+                "nl": "Feloranjegeel",
+                "es": "Amarillo mandarina"
+            },
+            "fila_color": [
+                "#FFC72CFF"
+            ]
+        },
+        {
+            "fila_color_code": "40401",
+            "fila_id": "GFB00",
+            "fila_color_type": "单色",
+            "fila_type": "ABS",
+            "fila_color_name": {
+                "de": "Beige",
+                "sv": "Beige",
+                "pt": "Bege",
+                "ko": "베이지",
+                "ja": "ベージュ",
+                "en": "Beige",
+                "it": "Beige",
+                "fr": "Beige",
+                "hu": "Bézs",
+                "zh": "卡其色",
+                "nl": "Beige",
+                "es": "Beis"
+            },
+            "fila_color": [
+                "#DFD1A7FF"
+            ]
+        },
+        {
+            "fila_color_code": "45600",
+            "fila_id": "GFB01",
+            "fila_color_type": "单色",
+            "fila_type": "ASA",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#2140B4FF"
+            ]
+        },
+        {
+            "fila_color_code": "45102",
+            "fila_id": "GFB01",
+            "fila_color_type": "单色",
+            "fila_type": "ASA",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#8A949EFF"
+            ]
+        },
+        {
+            "fila_color_code": "45500",
+            "fila_id": "GFB01",
+            "fila_color_type": "单色",
+            "fila_type": "ASA",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "绿色",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#00A6A0FF"
+            ]
+        },
+        {
+            "fila_color_code": "45101",
+            "fila_id": "GFB01",
+            "fila_color_type": "单色",
+            "fila_type": "ASA",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "45200",
+            "fila_id": "GFB01",
+            "fila_color_type": "单色",
+            "fila_type": "ASA",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#E02928FF"
+            ]
+        },
+        {
+            "fila_color_code": "45100",
+            "fila_id": "GFB01",
+            "fila_color_type": "单色",
+            "fila_type": "ASA",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFAF2FF"
+            ]
+        },
+        {
+            "fila_color_code": "46100",
+            "fila_id": "GFB02",
+            "fila_color_type": "单色",
+            "fila_type": "ASA Aero",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#F5F1DDFF"
+            ]
+        },
+        {
+            "fila_color_code": "41300",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Orange",
+                "sv": "Orange",
+                "pt": "Laranja",
+                "ko": "오렌지",
+                "ja": "オレンジ",
+                "en": "Orange",
+                "it": "Arancione",
+                "fr": "Orange",
+                "hu": "Narancssárga",
+                "zh": "橙色",
+                "nl": "Oranje",
+                "es": "Naranja"
+            },
+            "fila_color": [
+                "#F48438FF"
+            ]
+        },
+        {
+            "fila_color_code": "41600",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#0C3B95FF"
+            ]
+        },
+        {
+            "fila_color_code": "41102",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#C6C6C6FF"
+            ]
+        },
+        {
+            "fila_color_code": "41500",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "绿色",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#61BF36FF"
+            ]
+        },
+        {
+            "fila_color_code": "41101",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "41200",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#E83100FF"
+            ]
+        },
+        {
+            "fila_color_code": "41100",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "41400",
+            "fila_id": "GFB50",
+            "fila_color_type": "单色",
+            "fila_type": "ABS-GF",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#FFE133FF"
+            ]
+        },
+        {
+            "fila_color_code": "46101",
+            "fila_id": "GFB51",
+            "fila_color_type": "单色",
+            "fila_type": "ASA-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "60102",
+            "fila_id": "GFC00",
+            "fila_color_type": "单色",
+            "fila_type": "PC",
+            "fila_color_name": {
+                "de": "Klares Schwarz",
+                "sv": "Klar svart",
+                "pt": "Preto-claro",
+                "ko": "클리어 블랙",
+                "ja": "クリア ブラック",
+                "en": "Clear Black",
+                "it": "Nero trasparente",
+                "fr": "Noir transparent",
+                "hu": "Tiszta fekete",
+                "zh": "透明黑",
+                "nl": "Helder zwart",
+                "es": "Negro transparente"
+            },
+            "fila_color": [
+                "#68686580"
+            ]
+        },
+        {
+            "fila_color_code": "60103",
+            "fila_id": "GFC00",
+            "fila_color_type": "单色",
+            "fila_type": "PC",
+            "fila_color_name": {
+                "de": "Durchsichtig",
+                "sv": "Genomskinlig",
+                "pt": "Transparente",
+                "ko": "투명",
+                "ja": "トランスペアレント",
+                "en": "Transparent",
+                "it": "Trasparente",
+                "fr": "Transparent",
+                "hu": "Áttetsző",
+                "zh": "透明",
+                "nl": "Transparant",
+                "es": "Translúcido"
+            },
+            "fila_color": [
+                "#FFFFFF00"
+            ]
+        },
+        {
+            "fila_color_code": "60101",
+            "fila_id": "GFC00",
+            "fila_color_type": "单色",
+            "fila_type": "PC",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "60100",
+            "fila_id": "GFC00",
+            "fila_color_type": "单色",
+            "fila_type": "PC",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "63102",
+            "fila_id": "GFC01",
+            "fila_color_type": "单色",
+            "fila_type": "PC FR",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#A8A8AAFF"
+            ]
+        },
+        {
+            "fila_color_code": "63100",
+            "fila_id": "GFC01",
+            "fila_color_type": "单色",
+            "fila_type": "PC FR",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "63101",
+            "fila_id": "GFC01",
+            "fila_color_type": "单色",
+            "fila_type": "PC FR",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "32300",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Orange",
+                "sv": "Genomskinlig orange",
+                "pt": "Laranja Translúcido",
+                "ko": "반투명 오렌지",
+                "ja": "トランスルーセント オレンジ",
+                "en": "Translucent Orange",
+                "it": "Arancione traslucido",
+                "fr": "Orange translucide",
+                "hu": "Áttetsző narancssárga",
+                "zh": "透明橘",
+                "nl": "Doorschijnend oranje",
+                "es": "Naranja translúcido"
+            },
+            "fila_color": [
+                "#FF911A80"
+            ]
+        },
+        {
+            "fila_color_code": "32600",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Hellblau",
+                "sv": "Genomskinlig ljusblå",
+                "pt": "Azul-claro Translúcido",
+                "ko": "반투명 라이트 블루",
+                "ja": "トランスルーセント ライト ブルー",
+                "en": "Translucent Light Blue",
+                "it": "Azzurro traslucido",
+                "fr": "Bleu clair translucide",
+                "hu": "Áttetsző világoskék",
+                "zh": "透明浅蓝",
+                "nl": "Doorschijnend lichtblauw",
+                "es": "Azul claro translúcido"
+            },
+            "fila_color": [
+                "#61B0FF80"
+            ]
+        },
+        {
+            "fila_color_code": "32101",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Klar",
+                "sv": "Klar",
+                "pt": "Claro",
+                "ko": "클리어",
+                "ja": "クリア",
+                "en": "Clear",
+                "it": "Trasparente",
+                "fr": "Transparent",
+                "hu": "Átlátszó",
+                "zh": "透明",
+                "nl": "Helder",
+                "es": "Transparente"
+            },
+            "fila_color": [
+                "#FFFFFF00"
+            ]
+        },
+        {
+            "fila_color_code": "32100",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Grau",
+                "sv": "Genomskinlig grå",
+                "pt": "Cinza Translúcido",
+                "ko": "반투명 그레이",
+                "ja": "トランスルーセント グレー",
+                "en": "Translucent Gray",
+                "it": "Grigio traslucido",
+                "fr": "Gris translucide",
+                "hu": "Áttetsző szürke",
+                "zh": "透明灰",
+                "nl": "Doorschijnend grijs",
+                "es": "Gris translúcido"
+            },
+            "fila_color": [
+                "#8E8E8E80"
+            ]
+        },
+        {
+            "fila_color_code": "32500",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Olivgrün",
+                "sv": "Genomskinlig oliv",
+                "pt": "Oliva Translúcido",
+                "ko": "반투명 올리브",
+                "ja": "トランスルーセント オリーブ",
+                "en": "Translucent Olive",
+                "it": "Oliva traslucido",
+                "fr": "Olive translucide",
+                "hu": "Áttetsző olivazöld",
+                "zh": "透明橄榄绿",
+                "nl": "Doorschijnend olijf",
+                "es": "Oliva translúcido"
+            },
+            "fila_color": [
+                "#748C4580"
+            ]
+        },
+        {
+            "fila_color_code": "32501",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Blaugrün",
+                "sv": "Genomskinlig teal",
+                "pt": "Azul-petróleo Translúcido",
+                "ko": "반투명 틸",
+                "ja": "トランスルーセント ティール",
+                "en": "Translucent Teal",
+                "it": "Verde petrolio traslucido",
+                "fr": "Bleu sarcelle translucide",
+                "hu": "Áttetsző kékeszöld",
+                "zh": "透明浅绿",
+                "nl": "Doorschijnend blauwgroen",
+                "es": "Verde azulado translúcido"
+            },
+            "fila_color": [
+                "#77EDD780"
+            ]
+        },
+        {
+            "fila_color_code": "32800",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Braun",
+                "sv": "Genomskinlig brun",
+                "pt": "Marrom Translúcido",
+                "ko": "반투명 브라운",
+                "ja": "トランスルーセント ブラウン",
+                "en": "Translucent Brown",
+                "it": "Marrone traslucido",
+                "fr": "Marron translucide",
+                "hu": "Áttetsző barna",
+                "zh": "透明茶色",
+                "nl": "Doorschijnend bruin",
+                "es": "Marrón translúcido"
+            },
+            "fila_color": [
+                "#C9A38180"
+            ]
+        },
+        {
+            "fila_color_code": "32700",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Lila",
+                "sv": "Genomskinlig lila",
+                "pt": "Roxo Translúcido",
+                "ko": "반투명 퍼플",
+                "ja": "トランスルーセント パープル",
+                "en": "Translucent Purple",
+                "it": "Viola traslucido",
+                "fr": "Violet translucide",
+                "hu": "Áttetsző lila",
+                "zh": "透明紫",
+                "nl": "Doorschijnend paars",
+                "es": "Púrpura translúcido"
+            },
+            "fila_color": [
+                "#D6ABFF80"
+            ]
+        },
+        {
+            "fila_color_code": "32200",
+            "fila_id": "GFG01",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Translucent",
+            "fila_color_name": {
+                "de": "Durchsichtiges Pink",
+                "sv": "Genomskinlig rosa",
+                "pt": "Rosa Translúcido",
+                "ko": "반투명 핑크",
+                "ja": "トランスルーセント ピンク",
+                "en": "Translucent Pink",
+                "it": "Rosa traslucido",
+                "fr": "Rose translucide",
+                "hu": "Áttetsző rózsaszín",
+                "zh": "透明粉",
+                "nl": "Doorschijnend roze",
+                "es": "Rosa translúcido"
+            },
+            "fila_color": [
+                "#F9C1BD80"
+            ]
+        },
+        {
+            "fila_color_code": "33300",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Orange",
+                "sv": "Orange",
+                "pt": "Laranja",
+                "ko": "오렌지",
+                "ja": "オレンジ",
+                "en": "Orange",
+                "it": "Arancione",
+                "fr": "Orange",
+                "hu": "Narancssárga",
+                "zh": "橙色",
+                "nl": "Oranje",
+                "es": "Naranja"
+            },
+            "fila_color": [
+                "#F75403FF"
+            ]
+        },
+        {
+            "fila_color_code": "33600",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#002E96FF"
+            ]
+        },
+        {
+            "fila_color_code": "33601",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Blauer See",
+                "sv": "Sjöblå",
+                "pt": "Lago Azul",
+                "ko": "레이크 블루",
+                "ja": "レイク ブルー",
+                "en": "Lake Blue",
+                "it": "Blu lago",
+                "fr": "Bleu lac",
+                "hu": "Vízkék",
+                "zh": "湖蓝",
+                "nl": "Meerblauw",
+                "es": "Azul Lago"
+            },
+            "fila_color": [
+                "#1F79E5FF"
+            ]
+        },
+        {
+            "fila_color_code": "33101",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#ADB1B2FF"
+            ]
+        },
+        {
+            "fila_color_code": "33103",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Dunkelgrau",
+                "sv": "Mörkgrå",
+                "pt": "Cinza-escuro",
+                "ko": "다크 그레이",
+                "ja": "ダーク グレー",
+                "en": "Dark Gray",
+                "it": "Grigio scuro",
+                "fr": "Gris foncé",
+                "hu": "Sötétszürke",
+                "zh": "深灰",
+                "nl": "Donkergrijs",
+                "es": "Gris oscuro"
+            },
+            "fila_color": [
+                "#515151FF"
+            ]
+        },
+        {
+            "fila_color_code": "33500",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "绿色",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#00AE42FF"
+            ]
+        },
+        {
+            "fila_color_code": "33501",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Limettengrün",
+                "sv": "Limegrön",
+                "pt": "Verde-limão",
+                "ko": "라임 그린",
+                "ja": "ライム グリーン",
+                "en": "Lime Green",
+                "it": "Verde lime",
+                "fr": "Vert citron",
+                "hu": "Limezöld",
+                "zh": "柠檬绿",
+                "nl": "Limoengroen",
+                "es": "Verde lima"
+            },
+            "fila_color": [
+                "#6EE53CFF"
+            ]
+        },
+        {
+            "fila_color_code": "33502",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Waldgrün",
+                "sv": "Skogsgrön",
+                "pt": "Verde-floresta",
+                "ko": "포레스트 그린",
+                "ja": "フォレスト グリーン",
+                "en": "Forest Green",
+                "it": "Verde foresta",
+                "fr": "Vert forêt",
+                "hu": "Erdőzöld",
+                "zh": "丛林绿",
+                "nl": "Bosgroen",
+                "es": "Verde bosque"
+            },
+            "fila_color": [
+                "#39541AFF"
+            ]
+        },
+        {
+            "fila_color_code": "33102",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "33801",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Erdnussbraun",
+                "sv": "Jordnötsbrun",
+                "pt": "Peanut Brown",
+                "ko": "피넛 브라운",
+                "ja": "ピーナッツ ブラウン",
+                "en": "Peanut Brown",
+                "it": "Cognac",
+                "fr": "Marron cacahuète",
+                "hu": "Mogyoróbarna",
+                "zh": "花生棕",
+                "nl": "Pindabruin",
+                "es": "Marrón cacahuete"
+            },
+            "fila_color": [
+                "#875718FF"
+            ]
+        },
+        {
+            "fila_color_code": "33200",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#BC0900FF"
+            ]
+        },
+        {
+            "fila_color_code": "33100",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "33400",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#FFD00BFF"
+            ]
+        },
+        {
+            "fila_color_code": "33401",
+            "fila_id": "GFG02",
+            "fila_color_type": "单色",
+            "fila_type": "PETG HF",
+            "fila_color_name": {
+                "de": "Creme",
+                "sv": "Cremevit",
+                "pt": "Creme",
+                "ko": "크림",
+                "ja": "クリーム",
+                "en": "Cream",
+                "it": "Panna",
+                "fr": "Crème",
+                "hu": "Törtfehér",
+                "zh": "奶油白",
+                "nl": "Roomkleurig",
+                "es": "Crema"
+            },
+            "fila_color": [
+                "#F9DFB9FF"
+            ]
+        },
+        {
+            "fila_color_code": "31600",
+            "fila_id": "GFG50",
+            "fila_color_type": "单色",
+            "fila_type": "PETG-CF",
+            "fila_color_name": {
+                "de": "Indigo-Blau",
+                "sv": "Indigoblå",
+                "pt": "Indigo Blue",
+                "ko": "인디고 블루",
+                "ja": "インディゴ ブルー",
+                "en": "Indigo Blue",
+                "it": "Blu indaco",
+                "fr": "Bleu indigo",
+                "hu": "Indigókék",
+                "zh": "靛蓝色",
+                "nl": "Indigoblauw",
+                "es": "Azul índigo"
+            },
+            "fila_color": [
+                "#324585FF"
+            ]
+        },
+        {
+            "fila_color_code": "31101",
+            "fila_id": "GFG50",
+            "fila_color_type": "单色",
+            "fila_type": "PETG-CF",
+            "fila_color_name": {
+                "de": "Titangrau",
+                "sv": "Titangrå",
+                "pt": "Titan Gray",
+                "ko": "타이탄 그레이",
+                "ja": "チタン グレー",
+                "en": "Titan Gray",
+                "it": "Grigio titanio",
+                "fr": "Gris titane",
+                "hu": "Titánszürke",
+                "zh": "钛灰色",
+                "nl": "Titaangrijs",
+                "es": "Gris titán"
+            },
+            "fila_color": [
+                "#565656FF"
+            ]
+        },
+        {
+            "fila_color_code": "31500",
+            "fila_id": "GFG50",
+            "fila_color_type": "单色",
+            "fila_type": "PETG-CF",
+            "fila_color_name": {
+                "de": "Malachitgrün",
+                "sv": "Malakitgrön",
+                "pt": "Verde Malaquita",
+                "ko": "말라카이트 그린",
+                "ja": "マラカイト グリーン",
+                "en": "Malachite Green",
+                "it": "Verde malachite",
+                "fr": "Vert malachite",
+                "hu": "Malachitzöld",
+                "zh": "孔雀绿",
+                "nl": "Malachietgroen",
+                "es": "Verde malaquita"
+            },
+            "fila_color": [
+                "#16b08eFF"
+            ]
+        },
+        {
+            "fila_color_code": "31100",
+            "fila_id": "GFG50",
+            "fila_color_type": "单色",
+            "fila_type": "PETG-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "31700",
+            "fila_id": "GFG50",
+            "fila_color_type": "单色",
+            "fila_type": "PETG-CF",
+            "fila_color_name": {
+                "de": "Lila-Violett",
+                "sv": "Violettlila",
+                "pt": "Violeta Roxo",
+                "ko": "바이올렛 퍼플",
+                "ja": "バイオレット パープル",
+                "en": "Violet Purple",
+                "it": "Viola",
+                "fr": "Violet pourpre",
+                "hu": "Viola",
+                "zh": "紫罗兰色",
+                "nl": "Violetpaars",
+                "es": "Violeta púrpura"
+            },
+            "fila_color": [
+                "#583061FF"
+            ]
+        },
+        {
+            "fila_color_code": "31200",
+            "fila_id": "GFG50",
+            "fila_color_type": "单色",
+            "fila_type": "PETG-CF",
+            "fila_color_name": {
+                "de": "Ziegelrot",
+                "sv": "Tegelröd",
+                "pt": "Vermelho Tijolo",
+                "ko": "브릭 레드",
+                "ja": "ブリック レッド",
+                "en": "Brick Red",
+                "it": "Rosso mattone",
+                "fr": "Rouge brique",
+                "hu": "Téglavörös",
+                "zh": "砖红色",
+                "nl": "Steenrood",
+                "es": "Rojo ladrillo"
+            },
+            "fila_color": [
+                "#9f332aFF"
+            ]
+        },
+        {
+            "fila_color_code": "70100",
+            "fila_id": "GFN04",
+            "fila_color_type": "单色",
+            "fila_type": "PAHT-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "72100",
+            "fila_id": "GFN05",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "73100",
+            "fila_id": "GFN06",
+            "fila_color_type": "单色",
+            "fila_type": "PPA-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "72600",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#75AED8FF"
+            ]
+        },
+        {
+            "fila_color_code": "72102",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#EAEAE4FF"
+            ]
+        },
+        {
+            "fila_color_code": "72103",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#353533FF"
+            ]
+        },
+        {
+            "fila_color_code": "72500",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Limette",
+                "sv": "Lime",
+                "pt": "Lima",
+                "ko": "라임",
+                "ja": "ライム",
+                "en": "Lime",
+                "it": "Lime",
+                "fr": "Citron vert",
+                "hu": "Lime",
+                "zh": "柠檬绿",
+                "nl": "Limoen",
+                "es": "Lima"
+            },
+            "fila_color": [
+                "#C5ED48FF"
+            ]
+        },
+        {
+            "fila_color_code": "72104",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "72800",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Braun",
+                "sv": "Brun",
+                "pt": "Marrom",
+                "ko": "브라운",
+                "ja": "ブラウン",
+                "en": "Brown",
+                "it": "Marrone",
+                "fr": "Marron",
+                "hu": "Barna",
+                "zh": "棕色",
+                "nl": "Bruin",
+                "es": "Marrón"
+            },
+            "fila_color": [
+                "#5B492FFF"
+            ]
+        },
+        {
+            "fila_color_code": "72200",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Orange",
+                "sv": "Orange",
+                "pt": "Laranja",
+                "ko": "오렌지",
+                "ja": "オレンジ",
+                "en": "Orange",
+                "it": "Arancione",
+                "fr": "Orange",
+                "hu": "Narancssárga",
+                "zh": "橙色",
+                "nl": "Oranje",
+                "es": "Naranja"
+            },
+            "fila_color": [
+                "#FF4800FF"
+            ]
+        },
+        {
+            "fila_color_code": "72400",
+            "fila_id": "GFN08",
+            "fila_color_type": "单色",
+            "fila_type": "PA6-GF",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#FFCE00FF"
+            ]
+        },
+        {
+            "fila_color_code": "65101",
+            "fila_id": "GFS02",
+            "fila_color_type": "单色",
+            "fila_type": "Support for PLA",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "65100",
+            "fila_id": "GFS02",
+            "fila_color_type": "单色",
+            "fila_type": "Support for PLA",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "65500",
+            "fila_id": "GFS03",
+            "fila_color_type": "单色",
+            "fila_type": "Support for PA/PET",
+            "fila_color_name": {
+                "de": "Grün",
+                "sv": "Grön",
+                "pt": "Verde",
+                "ko": "그린",
+                "ja": "グリーン",
+                "en": "Green",
+                "it": "Verde",
+                "fr": "Vert",
+                "hu": "Zöld",
+                "zh": "绿色",
+                "nl": "Groen",
+                "es": "Verde"
+            },
+            "fila_color": [
+                "#C0DF16FF"
+            ]
+        },
+        {
+            "fila_color_code": "66400",
+            "fila_id": "GFS04",
+            "fila_color_type": "单色",
+            "fila_type": "PVA",
+            "fila_color_name": {
+                "de": "Klar",
+                "sv": "Klar",
+                "pt": "Claro",
+                "ko": "클리어",
+                "ja": "クリア",
+                "en": "Clear",
+                "it": "Trasparente",
+                "fr": "Transparent",
+                "hu": "Átlátszó",
+                "zh": "透明浅黄色",
+                "nl": "Helder",
+                "es": "Transparente"
+            },
+            "fila_color": [
+                "#F0F1A880"
+            ]
+        },
+        {
+            "fila_color_code": "65102",
+            "fila_id": "GFS05",
+            "fila_color_type": "单色",
+            "fila_type": "Support for PLA/PETG",
+            "fila_color_name": {
+                "de": "Natur",
+                "sv": "Natur",
+                "pt": "Natureza",
+                "ko": "네이처",
+                "ja": "ネイチャー",
+                "en": "Nature",
+                "it": "Naturale",
+                "fr": "Nature",
+                "hu": "Natúr",
+                "zh": "半透明",
+                "nl": "Natuurlijk",
+                "es": "Naturaleza"
+            },
+            "fila_color": [
+                "#00000000"
+            ]
+        },
+        {
+            "fila_color_code": "65103",
+            "fila_id": "GFS05",
+            "fila_color_type": "单色",
+            "fila_type": "Support for PLA/PETG",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "66100",
+            "fila_id": "GFS06",
+            "fila_color_type": "单色",
+            "fila_type": "Support for ABS",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "71100",
+            "fila_id": "GFT01",
+            "fila_color_type": "单色",
+            "fila_type": "PET-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "76100",
+            "fila_id": "GFT02",
+            "fila_color_type": "单色",
+            "fila_type": "PPS-CF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "51600",
+            "fila_id": "GFU00",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A HF",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#0072CEFF"
+            ]
+        },
+        {
+            "fila_color_code": "51101",
+            "fila_id": "GFU00",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A HF",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#898D8DFF"
+            ]
+        },
+        {
+            "fila_color_code": "51100",
+            "fila_id": "GFU00",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A HF",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#101820FF"
+            ]
+        },
+        {
+            "fila_color_code": "51200",
+            "fila_id": "GFU00",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A HF",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#C8102EFF"
+            ]
+        },
+        {
+            "fila_color_code": "51102",
+            "fila_id": "GFU00",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A HF",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "51400",
+            "fila_id": "GFU00",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A HF",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#F3E600FF"
+            ]
+        },
+        {
+            "fila_color_code": "50101",
+            "fila_id": "GFU01",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "50100",
+            "fila_id": "GFU01",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 95A",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "53600",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Blau",
+                "sv": "Blå",
+                "pt": "Azul",
+                "ko": "블루",
+                "ja": "ブルー",
+                "en": "Blue",
+                "it": "Blu",
+                "fr": "Bleu",
+                "hu": "Kék",
+                "zh": "蓝色",
+                "nl": "Blauw",
+                "es": "Azul"
+            },
+            "fila_color": [
+                "#5898DDFF"
+            ]
+        },
+        {
+            "fila_color_code": "53102",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#939393FF"
+            ]
+        },
+        {
+            "fila_color_code": "53500",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Neongrün",
+                "sv": "Neongrön",
+                "pt": "Verde-neon",
+                "ko": "네온 그린",
+                "ja": "ネオン グリーン",
+                "en": "Neon Green",
+                "it": "Verde neon",
+                "fr": "Vert fluo",
+                "hu": "Neonzöld",
+                "zh": "荧光绿",
+                "nl": "Neongroen",
+                "es": "Verde neón"
+            },
+            "fila_color": [
+                "#90FF1AFF"
+            ]
+        },
+        {
+            "fila_color_code": "53101",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Schwarz",
+                "sv": "Svart",
+                "pt": "Preto",
+                "ko": "블랙",
+                "ja": "ブラック",
+                "en": "Black",
+                "it": "Nero",
+                "fr": "Noir",
+                "hu": "Fekete",
+                "zh": "黑色",
+                "nl": "Zwart",
+                "es": "Negro"
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "53200",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Rot",
+                "sv": "Röd",
+                "pt": "Vermelho",
+                "ko": "레드",
+                "ja": "レッド",
+                "en": "Red",
+                "it": "Rosso",
+                "fr": "Rouge",
+                "hu": "Piros",
+                "zh": "红色",
+                "nl": "Rood",
+                "es": "Rojo"
+            },
+            "fila_color": [
+                "#ED0000FF"
+            ]
+        },
+        {
+            "fila_color_code": "53100",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Weiß",
+                "sv": "Vit",
+                "pt": "Branco",
+                "ko": "화이트",
+                "ja": "ホワイト",
+                "en": "White",
+                "it": "Bianco",
+                "fr": "Blanc",
+                "hu": "Fehér",
+                "zh": "白色",
+                "nl": "Wit",
+                "es": "Blanco"
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "53400",
+            "fila_id": "GFU02",
+            "fila_color_type": "单色",
+            "fila_type": "TPU for AMS",
+            "fila_color_name": {
+                "de": "Gelb",
+                "sv": "Gul",
+                "pt": "Amarelo",
+                "ko": "옐로우",
+                "ja": "イエロー",
+                "en": "Yellow",
+                "it": "Giallo",
+                "fr": "Jaune",
+                "hu": "Sárga",
+                "zh": "黄色",
+                "nl": "Geel",
+                "es": "Amarillo"
+            },
+            "fila_color": [
+                "#F9EF41FF"
+            ]
+        },
+        {
+            "fila_color_code": "16100",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Black",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黑色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "16400",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Yellow",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黄色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#EFE255FF"
+            ]
+        },
+        {
+            "fila_color_code": "16103",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "White",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "白色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "16600",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Cyan",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "天蓝色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#4DAFDAFF"
+            ]
+        },
+        {
+            "fila_color_code": "16200",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Red",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "深红色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#C6001AFF"
+            ]
+        },
+        {
+            "fila_color_code": "16101",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "Grau",
+                "sv": "Grå",
+                "pt": "Cinza",
+                "ko": "그레이",
+                "ja": "グレー",
+                "en": "Gray",
+                "it": "Grigio",
+                "fr": "Gris",
+                "hu": "Szürke",
+                "zh": "灰色",
+                "nl": "Grijs",
+                "es": "Gris"
+            },
+            "fila_color": [
+                "#999D9DFF"
+            ]
+        },
+        {
+            "fila_color_code": "13210",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Red",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "透明红",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#B5001180"
+            ]
+        },
+        {
+            "fila_color_code": "13211",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Cherry Pink",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "果冻粉",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#F5B6CD80"
+            ]
+        },
+        {
+            "fila_color_code": "13301",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Orange",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "透明橙",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#F74E0280"
+            ]
+        },
+        {
+            "fila_color_code": "13410",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Mellow Yellow",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黄水晶",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#F5DBAB80"
+            ]
+        },
+        {
+            "fila_color_code": "13510",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Light Jade",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "浅青玉",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#96D8AF80"
+            ]
+        },
+        {
+            "fila_color_code": "13610",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Ice Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "冰蓝",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#B8CDE980"
+            ]
+        },
+        {
+            "fila_color_code": "13611",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "透明蓝",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#0047BB80"
+            ]
+        },
+        {
+            "fila_color_code": "13612",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Teal",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "蓝绿色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#009FA180"
+            ]
+        },
+        {
+            "fila_color_code": "13710",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Purple",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "透明紫",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#8344B080"
+            ]
+        },
+        {
+            "fila_color_code": "13711",
+            "fila_id": "GFA17",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Translucent",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Lavender",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "紫罗兰",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#B8ACD680"
+            ]
+        },
+        {
+            "fila_color_code": "13906",
+            "fila_id": "GFA05",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "South Beach",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "马卡龙",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#00918BFF",
+                "#F772A4FF"
+            ]
+        },
+        {
+            "fila_color_code": "13909",
+            "fila_id": "GFA05",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Aurora Purple",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "星云紫",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#7F3696FF",
+                "#006EC9FF"
+            ]
+        },
+        {
+            "fila_color_code": "13912",
+            "fila_id": "GFA05",
+            "fila_color_type": "渐变色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Dawn Radiance",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "浅彩虹",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#EC984CFF",
+                "#6CD4BCFF",
+                "#A66EB9FF",
+                "#D87694FF"
+            ]
+        },
+        {
+            "fila_color_code": "51103",
+            "fila_id": "GFU03",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Black",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黑色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "51105",
+            "fila_id": "GFU03",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "White",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "白色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "51305",
+            "fila_id": "GFU04",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 85A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Neon Orange",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "暖橙色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#F68B1BFF"
+            ]
+        },
+        {
+            "fila_color_code": "51500",
+            "fila_id": "GFU04",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 85A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Light Cyan",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "苍青色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#C3E2D6FF"
+            ]
+        },
+        {
+            "fila_color_code": "51900",
+            "fila_id": "GFU03",
+            "fila_color_type": "渐变色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Frozen",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "冰封蓝",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFFFFFFF",
+                "#40B6E4FF"
+            ]
+        },
+        {
+            "fila_color_code": "51901",
+            "fila_id": "GFU03",
+            "fila_color_type": "渐变色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Blaze",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "西瓜红",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#D21B3CFF",
+                "#F1AAA8FF"
+            ]
+        },
+        {
+            "fila_color_code": "65104",
+            "fila_id": "GFS02",
+            "fila_color_type": "单色",
+            "fila_type": "Support for PLA",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "White",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "白色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "12104",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Black",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黑色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "12105",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Gray",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "浅灰色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#AFB1AEFF"
+            ]
+        },
+        {
+            "fila_color_code": "12106",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Silver",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "银色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#959698FF"
+            ]
+        },
+        {
+            "fila_color_code": "12107",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "White",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "白色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "12301",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Orange",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "橙色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#DC3A27FF"
+            ]
+        },
+        {
+            "fila_color_code": "12401",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Yellow",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "亮黄色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#F4D53FFF"
+            ]
+        },
+        {
+            "fila_color_code": "12601",
+            "fila_id": "GFA10",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Tough+",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Cyan",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "天蓝色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#009BD8FF"
+            ]
+        },
+        {
+            "fila_color_code": "13100",
+            "fila_id": "GFA02",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Metal",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Iron Gray Metallic",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "深空灰",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#43403DFF"
+            ]
+        },
+        {
+            "fila_color_code": "13400",
+            "fila_id": "GFA02",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Metal",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Iridium Gold Metallic",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "香槟金",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#B39B84FF"
+            ]
+        },
+        {
+            "fila_color_code": "13500",
+            "fila_id": "GFA02",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Metal",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Oxide Green Metallic",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "极光绿",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#1D7C6AFF"
+            ]
+        },
+        {
+            "fila_color_code": "13600",
+            "fila_id": "GFA02",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Metal",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Cobalt Blue Metallic",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "典雅蓝",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#39699EFF"
+            ]
+        },
+        {
+            "fila_color_code": "13800",
+            "fila_id": "GFA02",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Metal",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Copper Brown Metallic",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "咖啡金",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#AA6443FF"
+            ]
+        },
+        {
+            "fila_color_code": "16601",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "蓝色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#004EA8FF"
+            ]
+        },
+        {
+            "fila_color_code": "16401",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Sunflower Yellow",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "橙黄色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFB549FF"
+            ]
+        },
+        {
+            "fila_color_code": "16501",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Green",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "绿色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#00BB31FF"
+            ]
+        },
+        {
+            "fila_color_code": "16301",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Orange",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "橙色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FF671FFF"
+            ]
+        },
+        {
+            "fila_color_code": "16700",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Matte Beige",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "浅肤色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#ECC3B2FF"
+            ]
+        },
+        {
+            "fila_color_code": "16800",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Cocoa Brown",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "棕色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#745335FF"
+            ]
+        },
+        {
+            "fila_color_code": "16102",
+            "fila_id": "GFA18",
+            "fila_color_type": "单色",
+            "fila_type": "PLA Lite",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Dark Gray",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "深灰",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#8c8b8cFF"
+            ]
+        },
+        {
+            "fila_color_code": "13913",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Mystic Magenta",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "北极光",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#720062FF",
+                "#3a913fFF"
+            ]
+        },
+        {
+            "fila_color_code": "13916",
+            "fila_id": "GFA05",
+            "fila_color_type": "多拼色",
+            "fila_type": "PLA Silk",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Phantom Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "幻影蓝",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#000000FF",
+                "#00629bFF"
+            ]
+        },
+        {
+            "fila_color_code": "51601",
+            "fila_id": "GFU03",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Crystal Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "水晶蓝",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#7eb4e180"
+            ]
+        },
+        {
+            "fila_color_code": "51106",
+            "fila_id": "GFU03",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Quicksilver",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "水银色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#9ea2a2FF"
+            ]
+        },
+        {
+            "fila_color_code": "51201",
+            "fila_id": "GFU04",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 85A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Flesh",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "肤色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#F3CFB2FF"
+            ]
+        },
+        {
+            "fila_color_code": "51700",
+            "fila_id": "GFU03",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Grape Jelly",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "果冻紫",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#D6ABFF80"
+            ]
+        },
+        {
+            "fila_color_code": "51107",
+            "fila_id": "GFU04",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 85A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Black",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黑色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "51501",
+            "fila_id": "GFU04",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 85A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Lime Green",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "苹果绿",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#CDEA80FF"
+            ]
+        },
+        {
+            "fila_color_code": "51800",
+            "fila_id": "GFU03",
+            "fila_color_type": "单色",
+            "fila_type": "TPU 90A",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Cocoa Brown",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "皮革棕",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#5C4738FF"
+            ]
+        },
+        {
+            "fila_color_code": "30105",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Black",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黑色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#000000FF"
+            ]
+        },
+        {
+            "fila_color_code": "30106",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "White",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "白色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FFFFFFFF"
+            ]
+        },
+        {
+            "fila_color_code": "30107",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Gray",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "灰色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#7F7E83FF"
+            ]
+        },
+        {
+            "fila_color_code": "30402",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Yellow",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "黄色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FCE300FF"
+            ]
+        },
+        {
+            "fila_color_code": "30201",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Red",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "红色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#D6001CFF"
+            ]
+        },
+        {
+            "fila_color_code": "30603",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Reflex Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "深蓝色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#001489FF"
+            ]
+        },
+        {
+            "fila_color_code": "30800",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Dark Brown",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "深棕色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#4f2c1dFF"
+            ]
+        },
+        {
+            "fila_color_code": "30502",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Green",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "绿色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#009639FF"
+            ]
+        },
+        {
+            "fila_color_code": "30301",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Orange",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "橙色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#FF671FFF"
+            ]
+        },
+        {
+            "fila_color_code": "30503",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Pine Green",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "墨绿色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#034638FF"
+            ]
+        },
+        {
+            "fila_color_code": "30604",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Navy Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "湖蓝色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#0086d6FF"
+            ]
+        },
+        {
+            "fila_color_code": "30108",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Misty Blue",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "蓝灰色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#688197FF"
+            ]
+        },
+        {
+            "fila_color_code": "30403",
+            "fila_id": "GFG00",
+            "fila_color_type": "单色",
+            "fila_type": "PETG Basic",
+            "fila_color_name": {
+                "de": "",
+                "sv": "",
+                "pt": "",
+                "ko": "",
+                "ja": "",
+                "en": "Dark Beige",
+                "it": "",
+                "fr": "",
+                "hu": "",
+                "zh": "深米色",
+                "nl": "",
+                "es": ""
+            },
+            "fila_color": [
+                "#dbc8b6FF"
+            ]
+        }
+    ],
+    "total": 304
+}


### PR DESCRIPTION
Adds `colordb.py`, a shared module for looking up official Bambu Lab colour names from the Bambu Studio colour database.

Features:
- Fetches the live database from GitHub (always up to date)
- Falls back to a local Bambu Studio installation if offline
- Falls back to a bundled `filaments_color_codes.json` as a last resort (updated automatically on each successful GitHub fetch)
- Exact hex-colour lookup filtered by material type and colour count
- Nearest-colour matching by Euclidean RGBA distance when no exact match

Also includes `filaments_color_codes.json` — a bundled snapshot of the Bambu Studio colour database, committed to the repository so the tools always have a working fallback even when offline.
